### PR TITLE
Add React Native mobile version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,8 @@ pnpm dev
 ```
 
 You should now be able to access the application at http://localhost:3000.
+
+### Mobile App
+
+The `mobile` directory contains a React Native version of the app built with Expo.
+Install dependencies inside that folder and run `pnpm start` to launch the Expo development server. Set `EXPO_PUBLIC_API_URL` in `mobile/.env` to the URL of your deployed backend so the mobile app can communicate with the same API.

--- a/app/(dashboard)/event.tsx
+++ b/app/(dashboard)/event.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { MoreHorizontal, RotateCcw, Bell } from 'lucide-react';
 import { TableCell, TableRow } from '@/components/ui/table';
-import { Event } from '@/lib/db';
+import { Event } from '@/shared/types';
 import { deleteEvent, resetEvent } from './actions';
 import { formatDistanceToNow } from 'date-fns';
 import { Badge } from '@/components/ui/badge';

--- a/app/(dashboard)/events-table.tsx
+++ b/app/(dashboard)/events-table.tsx
@@ -15,7 +15,7 @@ import {
   CardDescription
 } from '@/components/ui/card';
 import { EventItem } from './event';
-import { Event } from '@/lib/db';
+import { Event } from '@/shared/types';
 
 export function EventsTable({ events }: { events: Event[] }) {
   return (

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,0 +1,42 @@
+import { auth } from '@/lib/auth';
+import { getEvents, updateEvent } from '@/lib/db';
+import { eq } from 'drizzle-orm';
+import { events, db } from '@/lib/db';
+import { NextResponse } from 'next/server';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const id = Number(params.id);
+  const event = (
+    await db.select().from(events).where(eq(events.id, id)).limit(1)
+  )[0];
+
+  if (!event || event.userId !== session.user.email) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(event);
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const id = Number(params.id);
+  const body = await req.json();
+  const { name, date, reminderDays } = body;
+  const updated = await updateEvent(id, name, new Date(date), reminderDays);
+  return NextResponse.json(updated);
+}

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,25 @@
+import { auth } from '@/lib/auth';
+import { createEvent, getEvents } from '@/lib/db';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const events = await getEvents(session.user.email);
+  return NextResponse.json(events);
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { name, date } = body;
+  const event = await createEvent(session.user.email, name, new Date(date));
+  return NextResponse.json(event);
+}

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,2 @@
+# Base URL of the hosted web app used by the mobile app
+EXPO_PUBLIC_API_URL=https://dayssince.app

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import LoginScreen from './src/screens/LoginScreen';
+import SignupScreen from './src/screens/SignupScreen';
+import DashboardScreen from './src/screens/DashboardScreen';
+import AddEventScreen from './src/screens/AddEventScreen';
+import EditEventScreen from './src/screens/EditEventScreen';
+import AdminScreen from './src/screens/AdminScreen';
+
+export type RootStackParamList = {
+  Login: undefined;
+  Signup: undefined;
+  Dashboard: undefined;
+  AddEvent: undefined;
+  EditEvent: { id: number };
+  Admin: undefined;
+};
+
+const Stack = createStackNavigator<RootStackParamList>();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Signup" component={SignupScreen} />
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+        <Stack.Screen name="AddEvent" component={AddEventScreen} />
+        <Stack.Screen name="EditEvent" component={EditEventScreen} />
+        <Stack.Screen name="Admin" component={AdminScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,11 @@
+# Days Since Mobile
+
+This directory contains a React Native version of the Days Since app built with Expo. It reuses the same backend as the web app and fetches data from the existing API routes deployed on Vercel.
+
+## Development
+
+1. Install dependencies with `pnpm install` inside this `mobile` directory.
+2. Copy `.env.example` from the root and set `EXPO_PUBLIC_API_URL` to your deployed backend URL.
+3. Run `pnpm start` to launch Expo.
+
+The screens roughly mirror the functionality of the web application: login, signup, dashboard with events list, add/edit events and an admin screen for sending test emails.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,6 @@
+{
+  "name": "days-since-mobile",
+  "slug": "days-since-mobile",
+  "version": "1.0.0",
+  "sdkVersion": "50.0.0"
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,0 +1,3 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+module.exports = getDefaultConfig(__dirname);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "days-since-mobile",
+  "version": "1.0.0",
+  "main": "App.tsx",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~50.0.5",
+    "expo-status-bar": "~1.7.3",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/stack": "^6.3.17"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/mobile/src/screens/AddEventScreen.tsx
+++ b/mobile/src/screens/AddEventScreen.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../../App';
+import { createEvent } from '../services/api';
+
+type Props = {
+  navigation: StackNavigationProp<RootStackParamList, 'AddEvent'>;
+};
+
+export default function AddEventScreen({ navigation }: Props) {
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+
+  const handleAdd = async () => {
+    await createEvent(name, new Date(date));
+    navigation.goBack();
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Event Name"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Date (YYYY-MM-DD)"
+        value={date}
+        onChangeText={setDate}
+        style={styles.input}
+      />
+      <Button title="Add" onPress={handleAdd} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: {
+    borderColor: '#ccc',
+    borderWidth: 1,
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4
+  }
+});

--- a/mobile/src/screens/AdminScreen.tsx
+++ b/mobile/src/screens/AdminScreen.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../../App';
+import { sendTestEmail } from '../services/api';
+
+type Props = {
+  navigation: StackNavigationProp<RootStackParamList, 'Admin'>;
+};
+
+export default function AdminScreen({ navigation }: Props) {
+  const handleSendEmail = async () => {
+    await sendTestEmail();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title="Send Test Email" onPress={handleSendEmail} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 }
+});

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../../App';
+import { getEvents, logout } from '../services/api';
+import { Event } from '@/shared/types';
+
+type Props = {
+  navigation: StackNavigationProp<RootStackParamList, 'Dashboard'>;
+};
+
+export default function DashboardScreen({ navigation }: Props) {
+  const [events, setEvents] = useState<Event[]>([]);
+
+  const loadEvents = async () => {
+    const data = await getEvents();
+    setEvents(data);
+  };
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', loadEvents);
+    return unsubscribe;
+  }, [navigation]);
+
+  return (
+    <View style={styles.container}>
+      <Button title="Add Event" onPress={() => navigation.navigate('AddEvent')} />
+      <Button title="Admin" onPress={() => navigation.navigate('Admin')} />
+      <Button title="Logout" onPress={() => { logout(); navigation.replace('Login'); }} />
+      <FlatList
+        data={events}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <Text style={styles.name}>{item.name}</Text>
+            <Text>{new Date(item.date).toLocaleDateString()}</Text>
+            <Button
+              title="Edit"
+              onPress={() => navigation.navigate('EditEvent', { id: item.id })}
+            />
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  item: {
+    padding: 8,
+    borderBottomColor: '#ccc',
+    borderBottomWidth: 1,
+    marginBottom: 8
+  },
+  name: { fontWeight: 'bold' }
+});

--- a/mobile/src/screens/EditEventScreen.tsx
+++ b/mobile/src/screens/EditEventScreen.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RouteProp } from '@react-navigation/native';
+import { RootStackParamList } from '../../App';
+import { getEvent, updateEvent } from '../services/api';
+
+interface Props {
+  navigation: StackNavigationProp<RootStackParamList, 'EditEvent'>;
+  route: RouteProp<RootStackParamList, 'EditEvent'>;
+}
+
+export default function EditEventScreen({ navigation, route }: Props) {
+  const { id } = route.params;
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+
+  useEffect(() => {
+    getEvent(id).then((event) => {
+      if (event) {
+        setName(event.name);
+        setDate(event.date.split('T')[0]);
+      }
+    });
+  }, [id]);
+
+  const handleSave = async () => {
+    await updateEvent(id, name, new Date(date));
+    navigation.goBack();
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Event Name"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Date (YYYY-MM-DD)"
+        value={date}
+        onChangeText={setDate}
+        style={styles.input}
+      />
+      <Button title="Save" onPress={handleSave} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: {
+    borderColor: '#ccc',
+    borderWidth: 1,
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4
+  }
+});

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../../App';
+import { login } from '../services/api';
+
+type Props = {
+  navigation: StackNavigationProp<RootStackParamList, 'Login'>;
+};
+
+export default function LoginScreen({ navigation }: Props) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleLogin = async () => {
+    try {
+      await login(email, password);
+      navigation.replace('Dashboard');
+    } catch (e) {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Login</Text>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <Button title="Sign In" onPress={handleLogin} />
+      <Button title="Sign Up" onPress={() => navigation.navigate('Signup')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  title: { fontSize: 24, marginBottom: 16, textAlign: 'center' },
+  input: {
+    borderColor: '#ccc',
+    borderWidth: 1,
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4
+  },
+  error: { color: 'red', marginBottom: 12 }
+});

--- a/mobile/src/screens/SignupScreen.tsx
+++ b/mobile/src/screens/SignupScreen.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../../App';
+import { signup } from '../services/api';
+
+type Props = {
+  navigation: StackNavigationProp<RootStackParamList, 'Signup'>;
+};
+
+export default function SignupScreen({ navigation }: Props) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSignup = async () => {
+    try {
+      await signup(email, password, name);
+      navigation.replace('Dashboard');
+    } catch (e) {
+      setError('Signup failed');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Create Account</Text>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Name (optional)"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <Button title="Sign Up" onPress={handleSignup} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  title: { fontSize: 24, marginBottom: 16, textAlign: 'center' },
+  input: {
+    borderColor: '#ccc',
+    borderWidth: 1,
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4
+  },
+  error: { color: 'red', marginBottom: 12 }
+});

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -1,0 +1,62 @@
+import { Event } from '@/shared/types';
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'https://dayssince.app';
+
+export async function login(email: string, password: string) {
+  const res = await fetch(`${API_URL}/api/auth/callback/credentials`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  });
+  if (!res.ok) throw new Error('Login failed');
+}
+
+export async function signup(email: string, password: string, name?: string) {
+  const res = await fetch(`${API_URL}/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, name })
+  });
+  if (!res.ok) throw new Error('Signup failed');
+}
+
+export async function logout() {
+  await fetch(`${API_URL}/api/auth/signout`, { method: 'POST' });
+}
+
+export async function getEvents(): Promise<Event[]> {
+  const res = await fetch(`${API_URL}/api/events`);
+  if (!res.ok) throw new Error('Failed to fetch events');
+  return res.json();
+}
+
+export async function getEvent(id: number): Promise<Event | null> {
+  const res = await fetch(`${API_URL}/api/events/${id}`);
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function createEvent(name: string, date: Date) {
+  await fetch(`${API_URL}/api/events`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, date: date.toISOString() })
+  });
+}
+
+export async function updateEvent(
+  id: number,
+  name: string,
+  date: Date,
+  reminderDays?: number | null
+) {
+  await fetch(`${API_URL}/api/events/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, date: date.toISOString(), reminderDays })
+  });
+}
+
+export async function sendTestEmail() {
+  await fetch(`${API_URL}/api/reminders`, { method: 'POST' });
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/shared/*": ["../shared/*"]
+    }
+  }
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,0 +1,10 @@
+export interface Event {
+  id: number;
+  userId: string;
+  name: string;
+  date: string;
+  resetCount: number;
+  createdAt: string;
+  reminderDays: number | null;
+  reminderSent: boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "baseUrl": ".",
     "paths": {
       "@/components/*": ["components/*"],
-      "@/lib/*": ["lib/*"]
+      "@/lib/*": ["lib/*"],
+      "@/shared/*": ["shared/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- make shared types for reuse
- expose REST API for events
- reference shared types in dashboard components
- document mobile app setup
- add new mobile folder with Expo + screens
- configure TypeScript path alias

## Testing
- `pnpm test`
- `pnpm lint` *(fails: next not found)*