### PR TITLE
Fix timezone formatting for event dates

### DIFF
--- a/app/(dashboard)/__tests__/event-navigation.test.tsx
+++ b/app/(dashboard)/__tests__/event-navigation.test.tsx
@@ -191,6 +191,23 @@ describe('Event Navigation', () => {
 
     jest.useRealTimers();
   });
+
+  it('formats event date in UTC', () => {
+    const originalTZ = process.env.TZ;
+    process.env.TZ = 'America/New_York';
+
+    render(
+      <table>
+        <tbody>
+          <EventItem event={mockEvent} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText('January 1, 2024')).toBeInTheDocument();
+
+    process.env.TZ = originalTZ;
+  });
 });
 
 describe('Event Navigation Integration', () => {

--- a/app/(dashboard)/event.tsx
+++ b/app/(dashboard)/event.tsx
@@ -29,7 +29,8 @@ export function EventItem({ event }: { event: Event }) {
   const formattedDate = new Date(event.date).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
-    day: 'numeric'
+    day: 'numeric',
+    timeZone: 'UTC'
   });
 
   // Get relative time (e.g., "2 months ago")

--- a/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
+++ b/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
@@ -245,7 +245,7 @@ describe('EventAnalyticsPage', () => {
 
     // Use getAllByText since the date appears in multiple elements
     const dateElements = screen.getAllByText((content, element) => {
-      return element?.textContent?.includes('December 31, 2023') || false;
+      return element?.textContent?.includes('January 1, 2024') || false;
     });
     expect(dateElements.length).toBeGreaterThan(0);
   });

--- a/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
+++ b/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
@@ -250,6 +250,28 @@ describe('EventAnalyticsPage', () => {
     expect(dateElements.length).toBeGreaterThan(0);
   });
 
+  it('formats reset timestamps in UTC', async () => {
+    const originalTZ = process.env.TZ;
+    process.env.TZ = 'America/New_York';
+
+    mockAuth.mockResolvedValue({
+      user: { email: 'test@example.com' }
+    } as any);
+    mockGetEventAnalytics.mockResolvedValue(mockAnalyticsData as any);
+
+    const result = await EventAnalyticsPage({
+      params: Promise.resolve({ id: '1' })
+    });
+
+    render(result as React.ReactElement);
+
+    expect(screen.getByText('Feb 15, 2024')).toBeInTheDocument();
+    const timeElements = screen.getAllByText('10:00 AM');
+    expect(timeElements.length).toBeGreaterThan(0);
+
+    process.env.TZ = originalTZ;
+  });
+
   it('shows correct metric descriptions', async () => {
     mockAuth.mockResolvedValue({
       user: { email: 'test@example.com' }

--- a/app/(dashboard)/events/[id]/analytics-charts.tsx
+++ b/app/(dashboard)/events/[id]/analytics-charts.tsx
@@ -41,7 +41,8 @@ export function AnalyticsCharts({
       chartData.push({
         date: eventDate.toLocaleDateString('en-US', {
           month: 'short',
-          day: 'numeric'
+          day: 'numeric',
+          timeZone: 'UTC'
         }),
         fullDate: eventDate.toISOString(),
         daysCount: 0,
@@ -50,7 +51,8 @@ export function AnalyticsCharts({
       chartData.push({
         date: new Date().toLocaleDateString('en-US', {
           month: 'short',
-          day: 'numeric'
+          day: 'numeric',
+          timeZone: 'UTC'
         }),
         fullDate: new Date().toISOString(),
         daysCount: currentStreak,
@@ -65,7 +67,8 @@ export function AnalyticsCharts({
       chartData.push({
         date: currentDate.toLocaleDateString('en-US', {
           month: 'short',
-          day: 'numeric'
+          day: 'numeric',
+          timeZone: 'UTC'
         }),
         fullDate: currentDate.toISOString(),
         daysCount: 0,
@@ -84,7 +87,8 @@ export function AnalyticsCharts({
         chartData.push({
           date: resetDate.toLocaleDateString('en-US', {
             month: 'short',
-            day: 'numeric'
+            day: 'numeric',
+            timeZone: 'UTC'
           }),
           fullDate: resetDate.toISOString(),
           daysCount: periodLength,
@@ -95,7 +99,8 @@ export function AnalyticsCharts({
         chartData.push({
           date: resetDate.toLocaleDateString('en-US', {
             month: 'short',
-            day: 'numeric'
+            day: 'numeric',
+            timeZone: 'UTC'
           }),
           fullDate: resetDate.toISOString(),
           daysCount: 0,
@@ -113,7 +118,8 @@ export function AnalyticsCharts({
       chartData.push({
         date: now.toLocaleDateString('en-US', {
           month: 'short',
-          day: 'numeric'
+          day: 'numeric',
+          timeZone: 'UTC'
         }),
         fullDate: now.toISOString(),
         daysCount: currentDays,
@@ -134,7 +140,8 @@ export function AnalyticsCharts({
       const date = new Date(reset.resetAt);
       const monthKey = date.toLocaleDateString('en-US', {
         year: 'numeric',
-        month: 'short'
+        month: 'short',
+        timeZone: 'UTC'
       });
       monthlyData[monthKey] = (monthlyData[monthKey] || 0) + 1;
     });

--- a/app/(dashboard)/events/[id]/page.tsx
+++ b/app/(dashboard)/events/[id]/page.tsx
@@ -52,7 +52,8 @@ export default async function EventAnalyticsPage({
     const formattedDate = new Date(event.date).toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
-      day: 'numeric'
+      day: 'numeric',
+      timeZone: 'UTC'
     });
 
     return (
@@ -180,13 +181,15 @@ export default async function EventAnalyticsPage({
                           {new Date(reset.resetAt).toLocaleDateString('en-US', {
                             year: 'numeric',
                             month: 'short',
-                            day: 'numeric'
+                            day: 'numeric',
+                            timeZone: 'UTC'
                           })}
                         </div>
                         <div className="text-sm text-muted-foreground">
                           {new Date(reset.resetAt).toLocaleTimeString('en-US', {
                             hour: '2-digit',
-                            minute: '2-digit'
+                            minute: '2-digit',
+                            timeZone: 'UTC'
                           })}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- fix timezone inconsistency for dates in analytics pages
- update tests for the new UTC formatting

## Testing
- `pnpm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683faa53df448323b1f30f3ef86991f4