### PR TITLE
Implement optimistic updates on events

### DIFF
--- a/app/(dashboard)/reset-button.tsx
+++ b/app/(dashboard)/reset-button.tsx
@@ -18,9 +18,15 @@ import { resetEvent, resetEventWithDate } from './actions';
 
 interface ResetButtonProps {
   eventId: number;
+  onOptimisticReset?: (date: string) => void;
+  onOptimisticQuickReset?: () => void;
 }
 
-export function ResetButton({ eventId }: ResetButtonProps) {
+export function ResetButton({
+  eventId,
+  onOptimisticReset,
+  onOptimisticQuickReset
+}: ResetButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [resetDate, setResetDate] = useState('');
   const [progress, setProgress] = useState(0);
@@ -29,6 +35,7 @@ export function ResetButton({ eventId }: ResetButtonProps) {
     const formData = new FormData();
     formData.append('id', eventId.toString());
     resetEvent(formData);
+    onOptimisticQuickReset?.();
   };
 
   const handleLongPress = () => {
@@ -45,6 +52,7 @@ export function ResetButton({ eventId }: ResetButtonProps) {
     formData.append('id', eventId.toString());
     formData.append('resetDate', resetDate);
     resetEventWithDate(formData);
+    onOptimisticReset?.(resetDate);
     setIsModalOpen(false);
   };
 


### PR DESCRIPTION
## Summary
- add client-side optimistic updates to event table
- pass callbacks to EventItem for delete and reset actions
- update ResetButton to notify parent of resets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684070144f388323ac849bba441dee3d