### PR TITLE
Add email reminder env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,15 @@ AUTH_SECRET= # https://generate-secret.vercel.app/32
 # https://authjs.dev/getting-started/providers/github
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
+
+# Base URL of your deployed application
+NEXT_PUBLIC_APP_URL=
+
+# SMTP configuration for sending reminder emails
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+
+# Secret key used to authorize Vercel Cron jobs
+CRON_SECRET_KEY=

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CREATE TABLE products (
 
 Then, uncomment `app/api/seed.ts` and hit `http://localhost:3000/api/seed` to seed the database with products.
 
-Next, copy the `.env.example` file to `.env` and update the values. Follow the instructions in the `.env.example` file to set up your GitHub OAuth application.
+Next, copy the `.env.example` file to `.env` and update the values. In addition to your database and GitHub credentials, make sure to provide the SMTP settings used for sending reminder emails as well as a `CRON_SECRET_KEY` for securing the scheduled job.
 
 ```bash
 npm i -g vercel

--- a/app/api/cron/check-reminders/route.ts
+++ b/app/api/cron/check-reminders/route.ts
@@ -12,15 +12,18 @@ export async function GET(request: Request) {
 
   try {
     // Call the reminders API to send emails
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_APP_URL}/api/reminders`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        }
+    // Determine the base URL for the reminders API. Prefer NEXT_PUBLIC_APP_URL
+    // but fall back to NEXTAUTH_URL for production environments where the
+    // former might not be defined.
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL;
+
+    const response = await fetch(`${baseUrl}/api/reminders`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
       }
-    );
+    });
 
     if (!response.ok) {
       throw new Error('Failed to send reminders');


### PR DESCRIPTION
## Summary
- add fallback for reminder API URL when cron job runs
- document SMTP and cron config in README
- add email and cron environment variables to `.env.example`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6841c81f67388323bb966c0143c487b6