### PR TITLE
Prevent table navigation when reset dialog is open

### DIFF
--- a/app/(dashboard)/__tests__/event-navigation.test.tsx
+++ b/app/(dashboard)/__tests__/event-navigation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import { EventItem } from '../event';
 import { Event } from '@/lib/db';
@@ -107,6 +107,44 @@ describe('Event Navigation', () => {
       fireEvent.click(dropdownButton);
       expect(mockPush).not.toHaveBeenCalled();
     }
+  });
+
+  it('does not navigate when reset modal is open and clicked', () => {
+    const { useLongPress } = require('../../../lib/hooks/use-long-press');
+
+    let longPressCallback: () => void = () => {};
+    (useLongPress as jest.Mock).mockImplementationOnce(
+      ({ onLongPress, onClick }) => {
+        longPressCallback = onLongPress;
+        return {
+          onMouseDown: jest.fn(),
+          onMouseUp: jest.fn(),
+          onMouseLeave: jest.fn(),
+          onTouchStart: jest.fn(),
+          onTouchEnd: jest.fn(),
+          onClick: onClick || jest.fn(),
+          isPressed: false
+        };
+      }
+    );
+
+    render(
+      <table>
+        <tbody>
+          <EventItem event={mockEvent} />
+        </tbody>
+      </table>
+    );
+
+    // open the modal
+    act(() => {
+      longPressCallback();
+    });
+
+    const dateInput = screen.getByLabelText('Reset Date');
+    fireEvent.click(dateInput);
+
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('applies correct hover styles to table row', () => {

--- a/app/(dashboard)/event.tsx
+++ b/app/(dashboard)/event.tsx
@@ -16,9 +16,11 @@ import { formatDistanceToNow } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
 import { ResetButton } from './reset-button';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 export function EventItem({ event }: { event: Event }) {
   const router = useRouter();
+  const [isResetModalOpen, setIsResetModalOpen] = useState(false);
 
   // Calculate days since
   const daysSince = Math.floor(
@@ -52,6 +54,9 @@ export function EventItem({ event }: { event: Event }) {
     ) {
       return;
     }
+    if (isResetModalOpen) {
+      return;
+    }
     router.push(`/events/${event.id}`);
   };
 
@@ -81,7 +86,7 @@ export function EventItem({ event }: { event: Event }) {
         {relativeTime}
       </TableCell>
       <TableCell className="flex items-center gap-2">
-        <ResetButton eventId={event.id} />
+        <ResetButton eventId={event.id} onOpenChange={setIsResetModalOpen} />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button aria-haspopup="true" size="icon" variant="ghost">

--- a/app/(dashboard)/reset-button.tsx
+++ b/app/(dashboard)/reset-button.tsx
@@ -18,9 +18,10 @@ import { resetEvent, resetEventWithDate } from './actions';
 
 interface ResetButtonProps {
   eventId: number;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function ResetButton({ eventId }: ResetButtonProps) {
+export function ResetButton({ eventId, onOpenChange }: ResetButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [resetDate, setResetDate] = useState('');
   const [progress, setProgress] = useState(0);
@@ -117,8 +118,17 @@ export function ResetButton({ eventId }: ResetButtonProps) {
         </span>
       </Button>
 
-      <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
-        <DialogContent className="sm:max-w-[425px]">
+      <Dialog
+        open={isModalOpen}
+        onOpenChange={(open) => {
+          setIsModalOpen(open);
+          onOpenChange?.(open);
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-[425px]"
+          onClick={(e) => e.stopPropagation()}
+        >
           <DialogHeader>
             <DialogTitle>Reset Event</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
## Summary
- stop table row navigation when the Reset dialog is open
- expose `onOpenChange` from `ResetButton`
- test clicking inside the open dialog

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6841cb5d9c8c832383a63d507d284b8f