### PR TITLE
Add reminder controls to analytics page

### DIFF
--- a/app/(dashboard)/actions.ts
+++ b/app/(dashboard)/actions.ts
@@ -126,6 +126,31 @@ export async function editEvent(formData: FormData) {
   redirect('/');
 }
 
+export async function updateEventReminder(formData: FormData) {
+  const session = await auth();
+  if (!session?.user?.email) {
+    throw new Error('You must be logged in to update a reminder');
+  }
+
+  const id = Number(formData.get('id'));
+  const reminderEnabled = formData.get('reminder') === 'on';
+  const reminderDays = reminderEnabled
+    ? Number(formData.get('reminderDays'))
+    : null;
+
+  if (reminderEnabled && (!reminderDays || reminderDays < 1)) {
+    throw new Error('Please specify a valid number of days for the reminder');
+  }
+
+  await db
+    .update(events)
+    .set({ reminderDays, reminderSent: false })
+    .where(eq(events.id, id));
+
+  revalidatePath(`/events/${id}`);
+  revalidatePath('/');
+}
+
 export async function resetEvent(formData: FormData) {
   'use server';
   const id = formData.get('id') as string;

--- a/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
+++ b/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
@@ -20,6 +20,11 @@ jest.mock('@/lib/db', () => ({
   getEventAnalytics: jest.fn()
 }));
 
+// Mock the action used for updating reminders
+jest.mock('../../../actions', () => ({
+  updateEventReminder: jest.fn()
+}));
+
 // Mock the analytics charts component
 jest.mock('../analytics-charts', () => ({
   AnalyticsCharts: ({ event, currentStreak, totalResets }: any) => (
@@ -142,6 +147,24 @@ describe('EventAnalyticsPage', () => {
     render(result as React.ReactElement);
 
     expect(screen.getByText('Reminder every 14 days')).toBeInTheDocument();
+  });
+
+  it('includes reminder settings form', async () => {
+    mockAuth.mockResolvedValue({
+      user: { email: 'test@example.com' }
+    } as any);
+    mockGetEventAnalytics.mockResolvedValue(mockAnalyticsData as any);
+
+    const result = await EventAnalyticsPage({
+      params: Promise.resolve({ id: '1' })
+    });
+
+    render(result as React.ReactElement);
+
+    expect(screen.getByLabelText('Set a reminder')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Remind me after (days)')
+    ).toBeInTheDocument();
   });
 
   it('renders recent resets section when resets exist', async () => {

--- a/app/(dashboard)/events/[id]/page.tsx
+++ b/app/(dashboard)/events/[id]/page.tsx
@@ -4,6 +4,9 @@ import { redirect } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import {
   ArrowLeft,
   Calendar,
@@ -14,6 +17,7 @@ import {
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
 import { AnalyticsCharts } from './analytics-charts';
+import { updateEventReminder } from '../../actions';
 
 interface EventAnalyticsPageProps {
   params: Promise<{
@@ -84,6 +88,34 @@ export default async function EventAnalyticsPage({
               )}
             </div>
           </CardHeader>
+        </Card>
+
+        {/* Reminder Settings */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Reminder Settings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form action={updateEventReminder} className="space-y-4">
+              <input type="hidden" name="id" value={event.id} />
+              <div className="flex items-center space-x-2">
+                <Switch id="reminder" name="reminder" defaultChecked={!!event.reminderDays} />
+                <Label htmlFor="reminder">Set a reminder</Label>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="reminderDays">Remind me after (days)</Label>
+                <Input
+                  id="reminderDays"
+                  name="reminderDays"
+                  type="number"
+                  min="1"
+                  placeholder="e.g. 30"
+                  defaultValue={event.reminderDays ?? ''}
+                />
+              </div>
+              <Button type="submit">Save Reminder</Button>
+            </form>
+          </CardContent>
         </Card>
 
         {/* Analytics Cards */}


### PR DESCRIPTION
## Summary
- add new `updateEventReminder` server action
- enable reminder updates directly from analytics page
- test reminder form rendering on analytics page

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684480559db0832383237196a31c7845