### PR TITLE
Add autocomplete to add event title

### DIFF
--- a/app/(dashboard)/add/page.tsx
+++ b/app/(dashboard)/add/page.tsx
@@ -11,8 +11,19 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { addEvent } from '../actions';
 import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { getEvents } from '@/lib/db';
+import { redirect } from 'next/navigation';
 
-export default function AddEventPage() {
+export default async function AddEventPage() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    redirect('/login');
+  }
+
+  const events = await getEvents(session.user.email);
+  const eventNames = Array.from(new Set(events.map((e) => e.name)));
+
   // Get today's date in YYYY-MM-DD format using local timezone
   const now = new Date();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
@@ -30,9 +41,15 @@ export default function AddEventPage() {
               <Input
                 id="name"
                 name="name"
+                list="eventSuggestions"
                 placeholder="What happened?"
                 required
               />
+              <datalist id="eventSuggestions" data-testid="event-suggestions">
+                {eventNames.map((name) => (
+                  <option key={name} value={name} />
+                ))}
+              </datalist>
             </div>
             <div className="space-y-2">
               <Label htmlFor="date">When did it happen?</Label>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -17,7 +17,8 @@ jest.mock('next/navigation', () => ({
   },
   usePathname() {
     return '';
-  }
+  },
+  redirect: jest.fn()
 }));
 
 // Server actions will be mocked in individual test files


### PR DESCRIPTION
## Summary
- fetch existing events for the current user in the add event page
- suggest existing event titles with a datalist
- mock auth and DB in add event tests
- update Jest setup with `redirect` mock
- add tests for login redirect and suggestion uniqueness

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6844f2510cd883239b9007ddd4e61c06