### PR TITLE
Add events import/export

### DIFF
--- a/app/(dashboard)/admin/import-export.tsx
+++ b/app/(dashboard)/admin/import-export.tsx
@@ -1,0 +1,55 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export function ImportExportEvents() {
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleExport = async () => {
+    const res = await fetch('/api/events/export');
+    if (!res.ok) return alert('Failed to export events');
+    const data = await res.json();
+    const blob = new Blob([JSON.stringify(data.events, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'events.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = async () => {
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const events = JSON.parse(text);
+      const res = await fetch('/api/events/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ events }),
+      });
+      if (!res.ok) throw new Error('Import failed');
+      setFile(null);
+      window.location.reload();
+    } catch {
+      alert('Invalid file');
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={handleExport}>Export Events</Button>
+      <Input
+        type="file"
+        accept="application/json"
+        onChange={(e) => setFile(e.target.files?.[0] || null)}
+      />
+      <Button onClick={handleImport} disabled={!file}>
+        Import Events
+      </Button>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -7,6 +7,7 @@ import {
   CardTitle
 } from '@/components/ui/card';
 import { sendTestEmail } from '../actions';
+import { ImportExportEvents } from './import-export';
 import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 
@@ -33,6 +34,15 @@ export default async function AdminPage() {
               This will send a test email to {session.user.email}
             </p>
           </form>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Import / Export Events</CardTitle>
+          <CardDescription>Backup or restore all of your events</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ImportExportEvents />
         </CardContent>
       </Card>
     </div>

--- a/app/api/events/export/route.ts
+++ b/app/api/events/export/route.ts
@@ -1,0 +1,20 @@
+import { auth } from '@/lib/auth';
+import { getEvents } from '@/lib/db';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const events = await getEvents(session.user.email);
+    return NextResponse.json({ events });
+  } catch (error) {
+    console.error('Error exporting events:', error);
+    return NextResponse.json({ error: 'Failed to export events' }, { status: 500 });
+  }
+}

--- a/app/api/events/import/route.ts
+++ b/app/api/events/import/route.ts
@@ -1,0 +1,34 @@
+import { auth } from '@/lib/auth';
+import { db, events } from '@/lib/db';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    if (!Array.isArray(body?.events)) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+
+    const insertValues = body.events.map((e: any) => ({
+      userId: session.user.email as string,
+      name: e.name as string,
+      date: new Date(e.date).toISOString(),
+      reminderDays: e.reminderDays ?? null,
+      reminderSent: false,
+    }));
+
+    await db.insert(events).values(insertValues);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error importing events:', error);
+    return NextResponse.json({ error: 'Failed to import events' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- implement new `GET /api/events/export` endpoint
- implement new `POST /api/events/import` endpoint
- add client component for importing and exporting events
- expose import/export UI on the Admin page

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6849abadc5608323bbf7659811cdb4df