### PR TITLE
Add tag support for events

### DIFF
--- a/app/(dashboard)/__tests__/add-event-page.test.tsx
+++ b/app/(dashboard)/__tests__/add-event-page.test.tsx
@@ -86,6 +86,7 @@ describe('Add Event Page', () => {
       // Check for form elements
       expect(screen.getByText('Add New Event')).toBeInTheDocument();
       expect(screen.getByLabelText('Event Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Tags')).toBeInTheDocument();
       expect(screen.getByLabelText('When did it happen?')).toBeInTheDocument();
       expect(screen.getByLabelText('Set a reminder')).toBeInTheDocument();
       expect(
@@ -101,12 +102,15 @@ describe('Add Event Page', () => {
       render(<AddEventPage />);
 
       const nameInput = screen.getByLabelText('Event Name');
+      const tagsInput = screen.getByLabelText('Tags');
       const dateInput = screen.getByLabelText('When did it happen?');
       const reminderDaysInput = screen.getByLabelText('Remind me after (days)');
 
       // Text inputs don't explicitly have type="text" in HTML
       expect(nameInput).toHaveAttribute('required');
       expect(nameInput).toHaveAttribute('placeholder', 'What happened?');
+
+      expect(tagsInput).toHaveAttribute('placeholder', 'comma separated');
 
       expect(dateInput).toHaveAttribute('type', 'date');
       expect(dateInput).toHaveAttribute('required');
@@ -133,6 +137,16 @@ describe('Add Event Page', () => {
       await user.type(nameInput, 'Test Event');
 
       expect(nameInput).toHaveValue('Test Event');
+    });
+
+    it('allows user to input tags', async () => {
+      const user = userEvent.setup();
+      render(<AddEventPage />);
+
+      const tagsInput = screen.getByLabelText('Tags');
+      await user.type(tagsInput, 'work, urgent');
+
+      expect(tagsInput).toHaveValue('work, urgent');
     });
 
     it('allows user to change the date', async () => {

--- a/app/(dashboard)/actions.ts
+++ b/app/(dashboard)/actions.ts
@@ -33,6 +33,8 @@ export async function addEvent(formData: FormData) {
 
   const name = formData.get('name') as string;
   const dateStr = formData.get('date') as string;
+  const tagsStr = formData.get('tags') as string | null;
+  const tags = tagsStr ? tagsStr.split(',').map(t => t.trim()).filter(Boolean) : [];
   const reminderEnabled = formData.get('reminder') === 'on';
   const reminderDays = reminderEnabled
     ? Number(formData.get('reminderDays'))
@@ -54,6 +56,7 @@ export async function addEvent(formData: FormData) {
       userId: session.user.email,
       name,
       date: date.toISOString(),
+      tags,
       reminderDays,
       reminderSent: false
     })
@@ -96,6 +99,8 @@ export async function editEvent(formData: FormData) {
   const id = Number(formData.get('id'));
   const name = formData.get('name') as string;
   const dateStr = formData.get('date') as string;
+  const tagsStr = formData.get('tags') as string | null;
+  const tags = tagsStr ? tagsStr.split(',').map(t => t.trim()).filter(Boolean) : [];
   const reminderEnabled = formData.get('reminder') === 'on';
   const reminderDays = reminderEnabled
     ? Number(formData.get('reminderDays'))
@@ -116,6 +121,7 @@ export async function editEvent(formData: FormData) {
     .set({
       name,
       date: date.toISOString(),
+      tags,
       reminderDays,
       reminderSent: false // Reset reminder status when updating reminder settings
     })

--- a/app/(dashboard)/add/page.tsx
+++ b/app/(dashboard)/add/page.tsx
@@ -35,6 +35,14 @@ export default function AddEventPage() {
               />
             </div>
             <div className="space-y-2">
+              <Label htmlFor="tags">Tags</Label>
+              <Input
+                id="tags"
+                name="tags"
+                placeholder="comma separated"
+              />
+            </div>
+            <div className="space-y-2">
               <Label htmlFor="date">When did it happen?</Label>
               <Input
                 id="date"

--- a/app/(dashboard)/edit/[id]/page.tsx
+++ b/app/(dashboard)/edit/[id]/page.tsx
@@ -57,6 +57,15 @@ export default async function EditEventPage({
               <Input id="name" name="name" defaultValue={event.name} required />
             </div>
             <div className="space-y-2">
+              <Label htmlFor="tags">Tags</Label>
+              <Input
+                id="tags"
+                name="tags"
+                defaultValue={(event.tags || []).join(', ')}
+                placeholder="comma separated"
+              />
+            </div>
+            <div className="space-y-2">
               <Label htmlFor="date">When did it happen?</Label>
               <Input
                 id="date"

--- a/app/(dashboard)/event.tsx
+++ b/app/(dashboard)/event.tsx
@@ -68,6 +68,11 @@ export function EventItem({ event }: { event: Event }) {
       <TableCell className="font-medium">
         <div className="flex items-center gap-2">
           {event.name}
+          {event.tags?.map((tag) => (
+            <Badge key={tag} variant="secondary">
+              {tag}
+            </Badge>
+          ))}
           {event.reminderDays && (
             <Badge variant={isReminderDue ? 'destructive' : 'secondary'}>
               <Bell className="h-3 w-3 mr-1" />

--- a/app/(dashboard)/events-table.tsx
+++ b/app/(dashboard)/events-table.tsx
@@ -22,6 +22,7 @@ import { Event } from '@/lib/db';
 
 export function EventsTable({ events }: { events: Event[] }) {
   const [query, setQuery] = useState('');
+  const [tagFilter, setTagFilter] = useState('');
 
   const fuse = useMemo(() => {
     return new Fuse(events, {
@@ -30,10 +31,15 @@ export function EventsTable({ events }: { events: Event[] }) {
     });
   }, [events]);
 
-  const filtered =
-    query.trim() === ''
-      ? events
-      : fuse.search(query).map((result) => result.item);
+  const filtered = (query.trim() === ''
+    ? events
+    : fuse.search(query).map((result) => result.item)).filter((e) =>
+    tagFilter === '' ? true : e.tags?.includes(tagFilter)
+  );
+
+  const allTags = Array.from(
+    new Set(events.flatMap((e) => e.tags ?? []))
+  );
 
   return (
     <Card>
@@ -44,13 +50,29 @@ export function EventsTable({ events }: { events: Event[] }) {
           event to view detailed analytics.
         </CardDescription>
         {events.length > 0 && (
-          <Input
-            placeholder="Search events..."
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            type="search"
-            className="mt-4 w-full sm:max-w-xs"
-          />
+          <div className="flex gap-2 mt-4">
+            <Input
+              placeholder="Search events..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              type="search"
+              className="w-full sm:max-w-xs"
+            />
+            {allTags.length > 0 && (
+              <select
+                className="border rounded-md p-2 text-sm"
+                value={tagFilter}
+                onChange={(e) => setTagFilter(e.target.value)}
+              >
+                <option value="">All Tags</option>
+                {allTags.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
         )}
       </CardHeader>
       <CardContent>

--- a/lib/db-migration.ts
+++ b/lib/db-migration.ts
@@ -6,7 +6,8 @@ import {
   pgTable,
   varchar,
   integer,
-  timestamp
+  timestamp,
+  boolean
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import * as dotenv from 'dotenv';
@@ -29,7 +30,10 @@ export const events = pgTable('events', {
   userId: varchar('user_id', { length: 255 }).notNull(),
   name: varchar('name', { length: 255 }).notNull(),
   date: varchar('date', { length: 255 }).notNull(),
-  resetCount: integer('reset_count').notNull().default(0)
+  resetCount: integer('reset_count').notNull().default(0),
+  reminderDays: integer('reminder_days'),
+  reminderSent: boolean('reminder_sent').notNull().default(false),
+  tags: varchar('tags', { length: 255 }).array().notNull().default(sql`'{}'`)
 });
 
 export const eventResets = pgTable('event_resets', {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -15,7 +15,7 @@ import {
   varchar,
   boolean
 } from 'drizzle-orm/pg-core';
-import { count, eq, ilike, desc, sql, and } from 'drizzle-orm';
+import { count, eq, ilike, desc, sql, and, arrayContains } from 'drizzle-orm';
 import { createInsertSchema } from 'drizzle-zod';
 
 // Define the schema
@@ -56,7 +56,8 @@ export const events = pgTable('events', {
   resetCount: integer('reset_count').notNull().default(0),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   reminderDays: integer('reminder_days'),
-  reminderSent: boolean('reminder_sent').notNull().default(false)
+  reminderSent: boolean('reminder_sent').notNull().default(false),
+  tags: varchar('tags', { length: 255 }).array().notNull().default(sql`'{}'`)
 });
 
 export const eventResets = pgTable('event_resets', {
@@ -176,11 +177,15 @@ export async function deleteProductById(id: number) {
   await db.delete(products).where(eq(products.id, id));
 }
 
-export async function getEvents(userId: string): Promise<Event[]> {
+export async function getEvents(userId: string, tag?: string): Promise<Event[]> {
+  const conditions = [eq(events.userId, userId)];
+  if (tag) {
+    conditions.push(arrayContains(events.tags, [tag]));
+  }
   const result = await db
     .select()
     .from(events)
-    .where(eq(events.userId, userId))
+    .where(and(...conditions))
     .orderBy(sql`${events.date} DESC`);
 
   // Add default value for resetCount if it's missing
@@ -193,7 +198,8 @@ export async function getEvents(userId: string): Promise<Event[]> {
 export async function createEvent(
   userId: string,
   name: string,
-  date: Date
+  date: Date,
+  tags: string[] = []
 ): Promise<Event> {
   // Convert Date to ISO string for Drizzle
   const dateStr = date.toISOString();
@@ -203,7 +209,8 @@ export async function createEvent(
     .values({
       userId,
       name,
-      date: dateStr
+      date: dateStr,
+      tags
     })
     .returning();
 
@@ -218,7 +225,8 @@ export async function updateEvent(
   id: number,
   name: string,
   date: Date,
-  reminderDays?: number | null
+  reminderDays?: number | null,
+  tags: string[] = []
 ): Promise<Event> {
   // Convert Date to ISO string for Drizzle
   const dateStr = date.toISOString();
@@ -229,7 +237,8 @@ export async function updateEvent(
       name,
       date: dateStr,
       reminderDays,
-      reminderSent: false // Reset reminder status when updating reminder settings
+      reminderSent: false, // Reset reminder status when updating reminder settings
+      tags
     })
     .where(eq(events.id, id))
     .returning();

--- a/scripts/run-migrations.ts
+++ b/scripts/run-migrations.ts
@@ -6,9 +6,10 @@ async function main() {
 
   // Add reminder columns to events table
   await db.execute(sql`
-    ALTER TABLE events 
+    ALTER TABLE events
     ADD COLUMN IF NOT EXISTS reminder_days INTEGER,
-    ADD COLUMN IF NOT EXISTS reminder_sent BOOLEAN NOT NULL DEFAULT FALSE;
+    ADD COLUMN IF NOT EXISTS reminder_sent BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS tags VARCHAR(255)[] NOT NULL DEFAULT '{}';
   `);
 
   console.log('Migrations completed successfully');


### PR DESCRIPTION
## Summary
- add `tags` field to event schema and migration scripts
- support tags in create/update operations
- allow filtering events by tag with UI dropdown
- expose tags field in add/edit forms and tests
- display tags in event rows

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68571c70450c8323bbc3ca35afceeaed