### PR TITLE
Remove reminder toggle

### DIFF
--- a/app/(dashboard)/__tests__/add-event-page.test.tsx
+++ b/app/(dashboard)/__tests__/add-event-page.test.tsx
@@ -87,10 +87,10 @@ describe('Add Event Page', () => {
       expect(screen.getByText('Add New Event')).toBeInTheDocument();
       expect(screen.getByLabelText('Event Name')).toBeInTheDocument();
       expect(screen.getByLabelText('When did it happen?')).toBeInTheDocument();
-      expect(screen.getByLabelText('Set a reminder')).toBeInTheDocument();
       expect(
         screen.getByLabelText('Remind me after (days)')
       ).toBeInTheDocument();
+      expect(screen.getByText('Optional')).toBeInTheDocument();
 
       // Check for buttons
       expect(screen.getByText('Cancel')).toBeInTheDocument();
@@ -146,16 +146,6 @@ describe('Add Event Page', () => {
       expect(dateInput).toHaveValue('2025-05-15');
     });
 
-    it('allows user to toggle reminder switch', async () => {
-      const user = userEvent.setup();
-      render(<AddEventPage />);
-
-      const reminderSwitch = screen.getByRole('switch');
-      expect(reminderSwitch).not.toBeChecked();
-
-      await user.click(reminderSwitch);
-      expect(reminderSwitch).toBeChecked();
-    });
 
     it('allows user to input reminder days', async () => {
       const user = userEvent.setup();
@@ -206,7 +196,6 @@ describe('Add Event Page', () => {
       // All inputs should have associated labels
       expect(screen.getByLabelText('Event Name')).toBeInTheDocument();
       expect(screen.getByLabelText('When did it happen?')).toBeInTheDocument();
-      expect(screen.getByLabelText('Set a reminder')).toBeInTheDocument();
       expect(
         screen.getByLabelText('Remind me after (days)')
       ).toBeInTheDocument();

--- a/app/(dashboard)/actions.ts
+++ b/app/(dashboard)/actions.ts
@@ -33,16 +33,14 @@ export async function addEvent(formData: FormData) {
 
   const name = formData.get('name') as string;
   const dateStr = formData.get('date') as string;
-  const reminderEnabled = formData.get('reminder') === 'on';
-  const reminderDays = reminderEnabled
-    ? Number(formData.get('reminderDays'))
-    : null;
+  const reminderDaysStr = formData.get('reminderDays') as string | null;
+  const reminderDays = reminderDaysStr ? Number(reminderDaysStr) : null;
 
   if (!name || !dateStr) {
     throw new Error('Name and date are required');
   }
 
-  if (reminderEnabled && (!reminderDays || reminderDays < 1)) {
+  if (reminderDays !== null && reminderDays < 1) {
     throw new Error('Please specify a valid number of days for the reminder');
   }
 
@@ -96,16 +94,14 @@ export async function editEvent(formData: FormData) {
   const id = Number(formData.get('id'));
   const name = formData.get('name') as string;
   const dateStr = formData.get('date') as string;
-  const reminderEnabled = formData.get('reminder') === 'on';
-  const reminderDays = reminderEnabled
-    ? Number(formData.get('reminderDays'))
-    : null;
+  const reminderDaysStr = formData.get('reminderDays') as string | null;
+  const reminderDays = reminderDaysStr ? Number(reminderDaysStr) : null;
 
   if (!name || !dateStr) {
     throw new Error('Name and date are required');
   }
 
-  if (reminderEnabled && (!reminderDays || reminderDays < 1)) {
+  if (reminderDays !== null && reminderDays < 1) {
     throw new Error('Please specify a valid number of days for the reminder');
   }
 

--- a/app/(dashboard)/add/page.tsx
+++ b/app/(dashboard)/add/page.tsx
@@ -8,7 +8,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
 import { addEvent } from '../actions';
 import Link from 'next/link';
 
@@ -44,10 +43,6 @@ export default function AddEventPage() {
                 required
               />
             </div>
-            <div className="flex items-center space-x-2">
-              <Switch id="reminder" name="reminder" />
-              <Label htmlFor="reminder">Set a reminder</Label>
-            </div>
             <div className="space-y-2">
               <Label htmlFor="reminderDays">Remind me after (days)</Label>
               <Input
@@ -57,6 +52,7 @@ export default function AddEventPage() {
                 min="1"
                 placeholder="e.g. 30"
               />
+              <p className="text-xs text-muted-foreground">Optional</p>
             </div>
           </CardContent>
           <CardFooter className="flex justify-between">

--- a/app/(dashboard)/edit/[id]/page.tsx
+++ b/app/(dashboard)/edit/[id]/page.tsx
@@ -8,7 +8,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
 import { editEvent } from '../../actions';
 import Link from 'next/link';
 import { db, events } from '@/lib/db';
@@ -66,14 +65,6 @@ export default async function EditEventPage({
                 required
               />
             </div>
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="reminder"
-                name="reminder"
-                defaultChecked={!!event.reminderDays}
-              />
-              <Label htmlFor="reminder">Set a reminder</Label>
-            </div>
             <div className="space-y-2">
               <Label htmlFor="reminderDays">Remind me after (days)</Label>
               <Input
@@ -84,6 +75,7 @@ export default async function EditEventPage({
                 placeholder="e.g. 30"
                 defaultValue={event.reminderDays || ''}
               />
+              <p className="text-xs text-muted-foreground">Optional</p>
             </div>
           </CardContent>
           <CardFooter className="flex justify-between">


### PR DESCRIPTION
## Summary
- drop the reminder toggle from add/edit forms
- parse reminder days directly in server actions
- update tests for new optional reminder text

## Testing
- `pnpm lint`
- `pnpm test && pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68571b6f9fa483238bb8901beee55cd6