### PR TITLE
Add database info to admin

### DIFF
--- a/app/(dashboard)/__tests__/admin-page.test.tsx
+++ b/app/(dashboard)/__tests__/admin-page.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AdminPage from '../admin/page';
+
+jest.mock('../actions', () => ({
+  sendTestEmail: jest.fn()
+}));
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(async () => ({ user: { email: 'test@example.com' } }))
+}));
+
+jest.mock('@/lib/db', () => ({
+  getDatabaseInfo: jest.fn(async () => ({
+    host: 'localhost',
+    database: 'testdb',
+    userCount: 1,
+    eventCount: 2,
+    productCount: 3
+  }))
+}));
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn()
+}));
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>{children}</a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+describe('AdminPage', () => {
+  it('renders database information', async () => {
+    const result = await AdminPage();
+    render(result as React.ReactElement);
+
+    expect(screen.getByText('Database')).toBeInTheDocument();
+    const host = screen.getByText(/Host:/).parentElement as HTMLElement;
+    expect(host).toHaveTextContent('Host: localhost');
+    const db = screen.getByText(/Database:/).parentElement as HTMLElement;
+    expect(db).toHaveTextContent('Database: testdb');
+    const users = screen.getByText(/Users:/).parentElement as HTMLElement;
+    expect(users).toHaveTextContent('Users: 1');
+    const events = screen.getByText(/Events:/).parentElement as HTMLElement;
+    expect(events).toHaveTextContent('Events: 2');
+    const products = screen.getByText(/Products:/).parentElement as HTMLElement;
+    expect(products).toHaveTextContent('Products: 3');
+  });
+});

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle
 } from '@/components/ui/card';
+import { getDatabaseInfo } from '@/lib/db';
 import { sendTestEmail } from '../actions';
 import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
@@ -16,6 +17,8 @@ export default async function AdminPage() {
   if (!session?.user?.email) {
     redirect('/login');
   }
+
+  const dbInfo = await getDatabaseInfo();
 
   return (
     <div className="grid gap-4 lg:grid-cols-1">
@@ -33,6 +36,31 @@ export default async function AdminPage() {
               This will send a test email to {session.user.email}
             </p>
           </form>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Database</CardTitle>
+          <CardDescription>
+            Information about the connected database
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-1 text-sm">
+          <p>
+            <span className="font-medium">Host:</span> {dbInfo.host}
+          </p>
+          <p>
+            <span className="font-medium">Database:</span> {dbInfo.database}
+          </p>
+          <p>
+            <span className="font-medium">Users:</span> {dbInfo.userCount}
+          </p>
+          <p>
+            <span className="font-medium">Events:</span> {dbInfo.eventCount}
+          </p>
+          <p>
+            <span className="font-medium">Products:</span> {dbInfo.productCount}
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -368,3 +368,31 @@ export async function getEventAnalytics(eventId: number, userId: string) {
     allResets: resets
   };
 }
+
+export async function getDatabaseInfo() {
+  const urlString = process.env.POSTGRES_URL ?? '';
+  let host = 'unknown';
+  let database = 'unknown';
+
+  try {
+    const url = new URL(urlString);
+    host = url.hostname;
+    database = url.pathname.replace('/', '');
+  } catch {
+    // ignore invalid URL
+  }
+
+  const [usersCount, eventsCount, productsCount] = await Promise.all([
+    db.select({ count: count() }).from(users),
+    db.select({ count: count() }).from(events),
+    db.select({ count: count() }).from(products)
+  ]);
+
+  return {
+    host,
+    database,
+    userCount: Number(usersCount[0]?.count ?? 0),
+    eventCount: Number(eventsCount[0]?.count ?? 0),
+    productCount: Number(productsCount[0]?.count ?? 0)
+  };
+}


### PR DESCRIPTION
## Summary
- add `getDatabaseInfo` helper
- display database information in the admin page
- test admin page database info rendering

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685c5811ebac8323a9f2a0ea43ca8af1