### PR TITLE
Implement optimistic add event

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+          run_install: true
+
+      - name: Setup environment
+        run: cp .env.example .env
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS Instructions
+
+This repository uses **pnpm** for development. Ensure dependencies are installed with `pnpm install`.
+
+Copy `.env.example` to `.env` and provide any required values before running scripts.
+
+Before committing any changes, run:
+
+```bash
+pnpm lint
+pnpm test
+```
+
+Before pushing, verify that tests and the build succeed:
+
+```bash
+pnpm test && pnpm build
+```
+
+Code style is enforced with Prettier and ESLint. Running `pnpm lint` will check formatting and lint rules.

--- a/app/(dashboard)/__tests__/add-event-page.test.tsx
+++ b/app/(dashboard)/__tests__/add-event-page.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AddEventPage from '../add/page';
+import { EventsProvider } from '@/components/events-context';
 
 // Mock the addEvent action
 jest.mock('../actions', () => ({
@@ -33,7 +34,11 @@ describe('Add Event Page', () => {
       jest.useFakeTimers();
       jest.setSystemTime(mockDate);
 
-      render(<AddEventPage />);
+      render(
+        <EventsProvider initialEvents={[]}>
+          <AddEventPage />
+        </EventsProvider>
+      );
 
       const dateInput = screen.getByLabelText(
         'When did it happen?'
@@ -49,7 +54,11 @@ describe('Add Event Page', () => {
       jest.useFakeTimers();
       jest.setSystemTime(mockDate);
 
-      render(<AddEventPage />);
+      render(
+        <EventsProvider initialEvents={[]}>
+          <AddEventPage />
+        </EventsProvider>
+      );
 
       const dateInput = screen.getByLabelText(
         'When did it happen?'
@@ -66,7 +75,7 @@ describe('Add Event Page', () => {
       jest.useFakeTimers();
       jest.setSystemTime(mockDate);
 
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const dateInput = screen.getByLabelText(
         'When did it happen?'
@@ -81,7 +90,7 @@ describe('Add Event Page', () => {
 
   describe('Form Rendering', () => {
     it('renders all required form elements', () => {
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       // Check for form elements
       expect(screen.getByText('Add New Event')).toBeInTheDocument();
@@ -98,7 +107,7 @@ describe('Add Event Page', () => {
     });
 
     it('has correct input types and attributes', () => {
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const nameInput = screen.getByLabelText('Event Name');
       const dateInput = screen.getByLabelText('When did it happen?');
@@ -117,7 +126,7 @@ describe('Add Event Page', () => {
     });
 
     it('has correct form action', () => {
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const form = document.querySelector('form');
       expect(form).toBeInTheDocument();
@@ -127,7 +136,7 @@ describe('Add Event Page', () => {
   describe('User Interactions', () => {
     it('allows user to input event name', async () => {
       const user = userEvent.setup();
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const nameInput = screen.getByLabelText('Event Name');
       await user.type(nameInput, 'Test Event');
@@ -137,7 +146,7 @@ describe('Add Event Page', () => {
 
     it('allows user to change the date', async () => {
       const user = userEvent.setup();
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const dateInput = screen.getByLabelText('When did it happen?');
       await user.clear(dateInput);
@@ -148,7 +157,7 @@ describe('Add Event Page', () => {
 
     it('allows user to toggle reminder switch', async () => {
       const user = userEvent.setup();
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const reminderSwitch = screen.getByRole('switch');
       expect(reminderSwitch).not.toBeChecked();
@@ -159,7 +168,7 @@ describe('Add Event Page', () => {
 
     it('allows user to input reminder days', async () => {
       const user = userEvent.setup();
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const reminderDaysInput = screen.getByLabelText('Remind me after (days)');
       await user.type(reminderDaysInput, '30');
@@ -170,7 +179,7 @@ describe('Add Event Page', () => {
 
   describe('Navigation', () => {
     it('has cancel button that links to home page', () => {
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const cancelButton = screen.getByText('Cancel');
       expect(cancelButton.closest('a')).toHaveAttribute('href', '/');
@@ -179,7 +188,7 @@ describe('Add Event Page', () => {
 
   describe('Form Validation', () => {
     it('marks required fields as required', () => {
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const nameInput = screen.getByLabelText('Event Name');
       const dateInput = screen.getByLabelText('When did it happen?');
@@ -189,7 +198,7 @@ describe('Add Event Page', () => {
     });
 
     it('has proper form structure for server action', () => {
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       const form = document.querySelector('form');
       const submitButton = screen.getByText('Add Event');
@@ -201,7 +210,7 @@ describe('Add Event Page', () => {
 
   describe('Accessibility', () => {
     it('has proper labels for all form controls', () => {
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       // All inputs should have associated labels
       expect(screen.getByLabelText('Event Name')).toBeInTheDocument();
@@ -213,7 +222,7 @@ describe('Add Event Page', () => {
     });
 
     it('has proper semantic structure', () => {
-      render(<AddEventPage />);
+      render(<EventsProvider initialEvents={[]}><AddEventPage /></EventsProvider>);
 
       // Should have a proper heading
       expect(

--- a/app/(dashboard)/__tests__/event-navigation.test.tsx
+++ b/app/(dashboard)/__tests__/event-navigation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import { EventItem } from '../event';
 import { Event } from '@/lib/db';
@@ -107,6 +107,44 @@ describe('Event Navigation', () => {
       fireEvent.click(dropdownButton);
       expect(mockPush).not.toHaveBeenCalled();
     }
+  });
+
+  it('does not navigate when reset modal is open and clicked', () => {
+    const { useLongPress } = require('../../../lib/hooks/use-long-press');
+
+    let longPressCallback: () => void = () => {};
+    (useLongPress as jest.Mock).mockImplementationOnce(
+      ({ onLongPress, onClick }) => {
+        longPressCallback = onLongPress;
+        return {
+          onMouseDown: jest.fn(),
+          onMouseUp: jest.fn(),
+          onMouseLeave: jest.fn(),
+          onTouchStart: jest.fn(),
+          onTouchEnd: jest.fn(),
+          onClick: onClick || jest.fn(),
+          isPressed: false
+        };
+      }
+    );
+
+    render(
+      <table>
+        <tbody>
+          <EventItem event={mockEvent} />
+        </tbody>
+      </table>
+    );
+
+    // open the modal
+    act(() => {
+      longPressCallback();
+    });
+
+    const dateInput = screen.getByLabelText('Reset Date');
+    fireEvent.click(dateInput);
+
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('applies correct hover styles to table row', () => {

--- a/app/(dashboard)/add/AddEventForm.tsx
+++ b/app/(dashboard)/add/AddEventForm.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { CardContent, CardFooter } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import Link from 'next/link';
+import { addEventWithoutRedirect } from '../actions';
+import { useEvents } from '@/components/events-context';
+
+export default function AddEventForm({ defaultDate }: { defaultDate: string }) {
+  const router = useRouter();
+  const { addEvent, updateEvent } = useEvents();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const name = formData.get('name') as string;
+    const date = formData.get('date') as string;
+    const reminder = formData.get('reminder') === 'on';
+    const reminderDays = reminder ? Number(formData.get('reminderDays')) : null;
+
+    const tempId = Date.now() * -1;
+    addEvent({
+      id: tempId,
+      name,
+      date: new Date(date).toISOString(),
+      reminderDays,
+      reminderSent: false,
+      resetCount: 0,
+      userId: ''
+    } as any);
+
+    router.push('/');
+    startTransition(async () => {
+      try {
+        const created = await addEventWithoutRedirect(formData);
+        updateEvent(created);
+      } catch (err) {
+        setError('Failed to add event');
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Event Name</Label>
+          <Input id="name" name="name" placeholder="What happened?" required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="date">When did it happen?</Label>
+          <Input
+            id="date"
+            name="date"
+            type="date"
+            defaultValue={defaultDate}
+            required
+          />
+        </div>
+        <div className="flex items-center space-x-2">
+          <Switch id="reminder" name="reminder" />
+          <Label htmlFor="reminder">Set a reminder</Label>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="reminderDays">Remind me after (days)</Label>
+          <Input
+            id="reminderDays"
+            name="reminderDays"
+            type="number"
+            min="1"
+            placeholder="e.g. 30"
+          />
+        </div>
+        {error && <p className="text-destructive text-sm">{error}</p>}
+      </CardContent>
+      <CardFooter className="flex justify-between">
+        <Button variant="outline" asChild>
+          <Link href="/">Cancel</Link>
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? 'Adding...' : 'Add Event'}
+        </Button>
+      </CardFooter>
+    </form>
+  );
+}

--- a/app/(dashboard)/add/page.tsx
+++ b/app/(dashboard)/add/page.tsx
@@ -1,16 +1,5 @@
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardFooter
-} from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { addEvent } from '../actions';
-import Link from 'next/link';
+import { Card, CardHeader, CardTitle } from '@/components/ui/card';
+import AddEventForm from './AddEventForm';
 
 export default function AddEventPage() {
   // Get today's date in YYYY-MM-DD format using local timezone
@@ -23,49 +12,7 @@ export default function AddEventPage() {
         <CardHeader>
           <CardTitle>Add New Event</CardTitle>
         </CardHeader>
-        <form action={addEvent}>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">Event Name</Label>
-              <Input
-                id="name"
-                name="name"
-                placeholder="What happened?"
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="date">When did it happen?</Label>
-              <Input
-                id="date"
-                name="date"
-                type="date"
-                defaultValue={today}
-                required
-              />
-            </div>
-            <div className="flex items-center space-x-2">
-              <Switch id="reminder" name="reminder" />
-              <Label htmlFor="reminder">Set a reminder</Label>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="reminderDays">Remind me after (days)</Label>
-              <Input
-                id="reminderDays"
-                name="reminderDays"
-                type="number"
-                min="1"
-                placeholder="e.g. 30"
-              />
-            </div>
-          </CardContent>
-          <CardFooter className="flex justify-between">
-            <Button variant="outline" asChild>
-              <Link href="/">Cancel</Link>
-            </Button>
-            <Button type="submit">Add Event</Button>
-          </CardFooter>
-        </form>
+        <AddEventForm defaultDate={today} />
       </Card>
     </div>
   );

--- a/app/(dashboard)/event.tsx
+++ b/app/(dashboard)/event.tsx
@@ -16,9 +16,24 @@ import { formatDistanceToNow } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
 import { ResetButton } from './reset-button';
 import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
 
-export function EventItem({ event }: { event: Event }) {
+interface EventItemProps {
+  event: Event;
+  onDelete?: (id: number) => void;
+  onReset?: (id: number, dateStr: string) => void;
+  onQuickReset?: (id: number) => void;
+}
+
+export function EventItem({
+  event,
+  onDelete,
+  onReset,
+  onQuickReset
+}: EventItemProps) {
   const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [isResetModalOpen, setIsResetModalOpen] = useState(false);
 
   // Calculate days since
   const daysSince = Math.floor(
@@ -52,6 +67,9 @@ export function EventItem({ event }: { event: Event }) {
     ) {
       return;
     }
+    if (isResetModalOpen) {
+      return;
+    }
     router.push(`/events/${event.id}`);
   };
 
@@ -81,7 +99,12 @@ export function EventItem({ event }: { event: Event }) {
         {relativeTime}
       </TableCell>
       <TableCell className="flex items-center gap-2">
-        <ResetButton eventId={event.id} />
+        <ResetButton
+          eventId={event.id}
+          onOptimisticReset={(date) => onReset?.(event.id, date)}
+          onOptimisticQuickReset={() => onQuickReset?.(event.id)}
+          onOpenChange={setIsResetModalOpen}
+        />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button aria-haspopup="true" size="icon" variant="ghost">
@@ -98,7 +121,17 @@ export function EventItem({ event }: { event: Event }) {
               <a href={`/edit/${event.id}`}>Edit</a>
             </DropdownMenuItem>
             <DropdownMenuItem>
-              <form action={deleteEvent}>
+              <form
+                action={deleteEvent}
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  onDelete?.(event.id);
+                  const fd = new FormData(e.currentTarget);
+                  startTransition(async () => {
+                    await deleteEvent(fd);
+                  });
+                }}
+              >
                 <input type="hidden" name="id" value={event.id} />
                 <button type="submit" className="w-full text-left">
                   Delete

--- a/app/(dashboard)/events-table.tsx
+++ b/app/(dashboard)/events-table.tsx
@@ -14,10 +14,58 @@ import {
   CardTitle,
   CardDescription
 } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { useState, useMemo, useTransition } from 'react';
+import Fuse from 'fuse.js';
 import { EventItem } from './event';
 import { Event } from '@/lib/db';
+import { deleteEvent, resetEvent, resetEventWithDate } from './actions';
+import { useEvents } from '@/components/events-context';
 
-export function EventsTable({ events }: { events: Event[] }) {
+export function EventsTable({ events: initialEvents }: { events?: Event[] }) {
+  const { events: contextEvents, removeEvent, updateEvent } = useEvents();
+  const events = initialEvents ?? contextEvents;
+  const [query, setQuery] = useState('');
+  const fuse = useMemo(() => {
+    return new Fuse(events, {
+      keys: ['name'],
+      threshold: 0.3
+    });
+  }, [events]);
+  const filtered =
+    query.trim() === '' ? events : fuse.search(query).map((r) => r.item);
+
+  const [, startTransition] = useTransition();
+
+  const handleDelete = (id: number) => {
+    removeEvent(id);
+    startTransition(async () => {
+      const fd = new FormData();
+      fd.append('id', id.toString());
+      await deleteEvent(fd);
+    });
+  };
+
+  const handleReset = (id: number, dateStr: string) => {
+    updateEvent({ id, date: dateStr } as Event);
+    startTransition(async () => {
+      const fd = new FormData();
+      fd.append('id', id.toString());
+      fd.append('resetDate', dateStr);
+      await resetEventWithDate(fd);
+    });
+  };
+
+  const handleQuickReset = (id: number) => {
+    const dateStr = new Date().toISOString();
+    updateEvent({ id, date: dateStr } as Event);
+    startTransition(async () => {
+      const fd = new FormData();
+      fd.append('id', id.toString());
+      await resetEvent(fd);
+    });
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -26,11 +74,24 @@ export function EventsTable({ events }: { events: Event[] }) {
           Track how many days have passed since important events. Click on any
           event to view detailed analytics.
         </CardDescription>
+        {events.length > 0 && (
+          <Input
+            placeholder="Search events..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            type="search"
+            className="mt-4 w-full sm:max-w-xs"
+          />
+        )}
       </CardHeader>
       <CardContent>
         {events.length === 0 ? (
           <div className="text-center py-6 text-muted-foreground">
             No events yet. Add your first event to get started!
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-6 text-muted-foreground">
+            No events match your search.
           </div>
         ) : (
           <Table>
@@ -44,8 +105,14 @@ export function EventsTable({ events }: { events: Event[] }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {events.map((event) => (
-                <EventItem key={event.id} event={event} />
+              {filtered.map((event) => (
+                <EventItem
+                  key={event.id}
+                  event={event}
+                  onDelete={handleDelete}
+                  onReset={handleReset}
+                  onQuickReset={handleQuickReset}
+                />
               ))}
             </TableBody>
           </Table>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -28,17 +28,26 @@ import { User } from './user';
 import Providers from './providers';
 import { NavItem } from './nav-item';
 import { SearchInput } from './search';
+import { EventsProvider } from '@/components/events-context';
+import { getEvents } from '@/lib/db';
+import { auth } from '@/lib/auth';
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children
 }: {
   children: React.ReactNode;
 }) {
+  const session = await auth();
+  const events = session?.user?.email
+    ? await getEvents(session.user.email)
+    : [];
+
   return (
     <Providers>
-      <main className="flex min-h-screen w-full flex-col bg-muted/40">
-        <DesktopNav />
-        <div className="flex flex-col sm:gap-4 sm:py-4 sm:pl-14">
+      <EventsProvider initialEvents={events}>
+        <main className="flex min-h-screen w-full flex-col bg-muted/40">
+          <DesktopNav />
+          <div className="flex flex-col sm:gap-4 sm:py-4 sm:pl-14">
           <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
             <MobileNav />
             <DashboardBreadcrumb />
@@ -49,7 +58,8 @@ export default function DashboardLayout({
           </main>
         </div>
         <Analytics />
-      </main>
+        </main>
+      </EventsProvider>
     </Providers>
   );
 }

--- a/app/(dashboard)/reset-button.tsx
+++ b/app/(dashboard)/reset-button.tsx
@@ -18,9 +18,17 @@ import { resetEvent, resetEventWithDate } from './actions';
 
 interface ResetButtonProps {
   eventId: number;
+  onOptimisticReset?: (date: string) => void;
+  onOptimisticQuickReset?: () => void;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function ResetButton({ eventId }: ResetButtonProps) {
+export function ResetButton({
+  eventId,
+  onOptimisticReset,
+  onOptimisticQuickReset,
+  onOpenChange
+}: ResetButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [resetDate, setResetDate] = useState('');
   const [progress, setProgress] = useState(0);
@@ -29,6 +37,7 @@ export function ResetButton({ eventId }: ResetButtonProps) {
     const formData = new FormData();
     formData.append('id', eventId.toString());
     resetEvent(formData);
+    onOptimisticQuickReset?.();
   };
 
   const handleLongPress = () => {
@@ -45,6 +54,7 @@ export function ResetButton({ eventId }: ResetButtonProps) {
     formData.append('id', eventId.toString());
     formData.append('resetDate', resetDate);
     resetEventWithDate(formData);
+    onOptimisticReset?.(resetDate);
     setIsModalOpen(false);
   };
 
@@ -117,8 +127,17 @@ export function ResetButton({ eventId }: ResetButtonProps) {
         </span>
       </Button>
 
-      <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
-        <DialogContent className="sm:max-w-[425px]">
+      <Dialog
+        open={isModalOpen}
+        onOpenChange={(open) => {
+          setIsModalOpen(open);
+          onOpenChange?.(open);
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-[425px]"
+          onClick={(e) => e.stopPropagation()}
+        >
           <DialogHeader>
             <DialogTitle>Reset Event</DialogTitle>
             <DialogDescription>

--- a/components/events-context.tsx
+++ b/components/events-context.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+import type { Event } from '@/lib/db';
+
+interface EventsContextValue {
+  events: Event[];
+  addEvent: (event: Event) => void;
+  updateEvent: (event: Event) => void;
+  removeEvent: (id: number) => void;
+}
+
+const EventsContext = createContext<EventsContextValue | undefined>(undefined);
+
+export function EventsProvider({
+  children,
+  initialEvents
+}: {
+  children: React.ReactNode;
+  initialEvents: Event[];
+}) {
+  const [events, setEvents] = useState<Event[]>(initialEvents);
+
+  const addEvent = (event: Event) => {
+    setEvents((prev) => [...prev, event]);
+  };
+
+  const updateEvent = (updated: Event) => {
+    setEvents((prev) =>
+      prev.map((e) => (e.id === updated.id ? { ...e, ...updated } : e))
+    );
+  };
+
+  const removeEvent = (id: number) => {
+    setEvents((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  return (
+    <EventsContext.Provider value={{ events, addEvent, updateEvent, removeEvent }}>
+      {children}
+    </EventsContext.Provider>
+  );
+}
+
+export function useEvents() {
+  const ctx = useContext(EventsContext);
+  if (!ctx) {
+    throw new Error('useEvents must be used within EventsProvider');
+  }
+  return ctx;
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "drizzle-kit": "^0.22.8",
     "drizzle-orm": "^0.31.4",
     "drizzle-zod": "^0.5.1",
+    "fuse.js": "^7.1.0",
     "lucide-react": "^0.400.0",
     "next": "15.3.0-canary.11",
     "next-auth": "5.0.0-beta.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       drizzle-zod:
         specifier: ^0.5.1
         version: 0.5.1(drizzle-orm@0.31.4(@neondatabase/serverless@0.9.5)(@types/pg@8.11.6)(@types/react@19.0.0)(react@19.0.0))(zod@3.24.1)
+      fuse.js:
+        specifier: ^7.1.0
+        version: 7.1.0
       lucide-react:
         specifier: ^0.400.0
         version: 0.400.0(react@19.0.0)
@@ -3375,6 +3378,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -8774,6 +8781,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fuse.js@7.1.0: {}
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION
## Summary
- introduce `EventsProvider` context to share event data
- wrap dashboard layout with the provider
- allow `EventsTable` to use shared context and search events
- implement client-side `AddEventForm` for optimistic adds
- expose `addEventWithoutRedirect` server action
- update unit tests for new provider
- merge main and resolve conflicts with new CI and lint rules

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684070144f388323ac849bba441dee3d