### PR TITLE
Enable optimistic UI on event creation form

### DIFF
--- a/app/(dashboard)/add/add-event-form.tsx
+++ b/app/(dashboard)/add/add-event-form.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useOptimistic, useTransition, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { addEvent } from '../actions';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { CardContent, CardFooter } from '@/components/ui/card';
+import Link from 'next/link';
+
+interface AddEventFormProps {
+  defaultDate: string;
+}
+
+export function AddEventForm({ defaultDate }: AddEventFormProps) {
+  const router = useRouter();
+  const [message, setMessage] = useOptimistic('');
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (message === 'Event added!') {
+      router.push('/');
+    }
+  }, [message, router]);
+
+  async function handleSubmit(formData: FormData) {
+    setMessage('Event added!');
+    startTransition(async () => {
+      await addEvent(formData);
+    });
+  }
+
+  return (
+    <form action={handleSubmit} className="contents">
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Event Name</Label>
+          <Input id="name" name="name" placeholder="What happened?" required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="date">When did it happen?</Label>
+          <Input
+            id="date"
+            name="date"
+            type="date"
+            defaultValue={defaultDate}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="reminderDays">Remind me after (days)</Label>
+          <Input
+            id="reminderDays"
+            name="reminderDays"
+            type="number"
+            min="1"
+            placeholder="e.g. 30"
+          />
+          <p className="text-xs text-muted-foreground">Optional</p>
+        </div>
+        {message && <p className="text-sm text-muted-foreground">{message}</p>}
+      </CardContent>
+      <CardFooter className="flex justify-between">
+        <Button variant="outline" asChild>
+          <Link href="/">Cancel</Link>
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? 'Adding...' : 'Add Event'}
+        </Button>
+      </CardFooter>
+    </form>
+  );
+}

--- a/app/(dashboard)/add/page.tsx
+++ b/app/(dashboard)/add/page.tsx
@@ -1,15 +1,5 @@
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardFooter
-} from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { addEvent } from '../actions';
-import Link from 'next/link';
+import { Card, CardHeader, CardTitle } from '@/components/ui/card';
+import { AddEventForm } from './add-event-form';
 
 export default function AddEventPage() {
   // Get today's date in YYYY-MM-DD format using local timezone
@@ -22,46 +12,7 @@ export default function AddEventPage() {
         <CardHeader>
           <CardTitle>Add New Event</CardTitle>
         </CardHeader>
-        <form action={addEvent}>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">Event Name</Label>
-              <Input
-                id="name"
-                name="name"
-                placeholder="What happened?"
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="date">When did it happen?</Label>
-              <Input
-                id="date"
-                name="date"
-                type="date"
-                defaultValue={today}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="reminderDays">Remind me after (days)</Label>
-              <Input
-                id="reminderDays"
-                name="reminderDays"
-                type="number"
-                min="1"
-                placeholder="e.g. 30"
-              />
-              <p className="text-xs text-muted-foreground">Optional</p>
-            </div>
-          </CardContent>
-          <CardFooter className="flex justify-between">
-            <Button variant="outline" asChild>
-              <Link href="/">Cancel</Link>
-            </Button>
-            <Button type="submit">Add Event</Button>
-          </CardFooter>
-        </form>
+        <AddEventForm defaultDate={today} />
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary
- add client-side `AddEventForm` component implementing optimistic UI feedback
- update `AddEventPage` to use the new form component

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685ec96c0818832397570fb55185e4b8