### PR TITLE
Add edit link on event page

### DIFF
--- a/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
+++ b/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
@@ -200,6 +200,23 @@ describe('EventAnalyticsPage', () => {
     expect(backLink).toHaveAttribute('href', '/');
   });
 
+  it('includes edit event link', async () => {
+    mockAuth.mockResolvedValue({
+      user: { email: 'test@example.com' }
+    } as any);
+    mockGetEventAnalytics.mockResolvedValue(mockAnalyticsData as any);
+
+    const result = await EventAnalyticsPage({
+      params: Promise.resolve({ id: '1' })
+    });
+
+    render(result as React.ReactElement);
+
+    const editLink = screen.getByRole('link', { name: /edit event/i });
+    expect(editLink).toBeInTheDocument();
+    expect(editLink).toHaveAttribute('href', '/edit/1');
+  });
+
   it('renders analytics charts component', async () => {
     mockAuth.mockResolvedValue({
       user: { email: 'test@example.com' }

--- a/app/(dashboard)/events/[id]/page.tsx
+++ b/app/(dashboard)/events/[id]/page.tsx
@@ -66,6 +66,9 @@ export default async function EventAnalyticsPage({
               Back to Events
             </Link>
           </Button>
+          <Button variant="secondary" size="sm" asChild>
+            <Link href={`/edit/${event.id}`}>Edit Event</Link>
+          </Button>
         </div>
 
         {/* Event Info */}


### PR DESCRIPTION
## Summary
- allow editing events from analytics page
- test edit link presence

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685ec91609e4832396396d75b963bf0f