### PR TITLE
Add CSV import/export for events

### DIFF
--- a/app/(dashboard)/actions.ts
+++ b/app/(dashboard)/actions.ts
@@ -250,3 +250,34 @@ export async function sendTestEmail() {
     throw error;
   }
 }
+
+export async function importEvents(formData: FormData) {
+  const session = await auth();
+  if (!session?.user?.email) {
+    throw new Error('You must be logged in to import events');
+  }
+
+  const file = formData.get('file') as File | null;
+  if (!file) {
+    throw new Error('CSV file is required');
+  }
+
+  const text = await file.text();
+  const lines = text.trim().split(/\r?\n/);
+  const rows = lines.slice(1); // skip header
+  for (const line of rows) {
+    if (!line.trim()) continue;
+    const [name, dateStr, reminderStr] = line.split(',');
+    if (!name || !dateStr) continue;
+    const reminderDays = reminderStr ? Number(reminderStr) : null;
+    await db.insert(events).values({
+      userId: session.user.email,
+      name,
+      date: new Date(dateStr).toISOString(),
+      reminderDays,
+      reminderSent: false
+    });
+  }
+
+  revalidatePath('/');
+}

--- a/app/(dashboard)/import/page.tsx
+++ b/app/(dashboard)/import/page.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { importEvents } from '../actions';
+
+export default async function ImportEventsPage() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="max-w-md mx-auto">
+      <Card>
+        <CardHeader>
+          <CardTitle>Import Events</CardTitle>
+        </CardHeader>
+        <form action={importEvents} encType="multipart/form-data">
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="file">CSV File</Label>
+              <Input id="file" name="file" type="file" accept=".csv" required />
+            </div>
+          </CardContent>
+          <CardFooter className="flex justify-between">
+            <Button variant="outline" asChild>
+              <Link href="/">Cancel</Link>
+            </Button>
+            <Button type="submit">Import</Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -28,6 +28,12 @@ export default async function DashboardPage() {
           <TabsTrigger value="overdue">Is overdue</TabsTrigger>
         </TabsList>
         <div className="ml-auto flex items-center gap-2">
+          <Button size="sm" variant="outline" asChild>
+            <a href="/api/events/export">Export CSV</a>
+          </Button>
+          <Button size="sm" variant="outline" asChild>
+            <Link href="/import">Import CSV</Link>
+          </Button>
           <Button size="sm" className="h-8 gap-1" asChild>
             <Link href="/add">
               <PlusCircle className="h-3.5 w-3.5" />

--- a/app/api/events/export/route.ts
+++ b/app/api/events/export/route.ts
@@ -1,0 +1,29 @@
+import { auth } from '@/lib/auth';
+import { db, events } from '@/lib/db';
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const userEvents = await db
+    .select()
+    .from(events)
+    .where(eq(events.userId, session.user.email));
+
+  const header = 'name,date,reminderDays\n';
+  const rows = userEvents
+    .map(e => `${e.name},${e.date},${e.reminderDays ?? ''}`)
+    .join('\n');
+  const csv = header + rows + (rows ? '\n' : '');
+
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': 'attachment; filename="events.csv"'
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- support exporting user events to CSV via new API route
- allow importing events from a CSV file
- add Import/Export buttons on dashboard

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685ec8db820483239a3b1a26b2caaea8