### PR TITLE
Add SMTP config and cron docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,13 @@ AUTH_SECRET= # https://generate-secret.vercel.app/32
 # https://authjs.dev/getting-started/providers/github
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
+
+# SMTP credentials for sending reminder emails
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=Days Since <reminders@dayssince.app>
+
+# Secret token for /api/cron/check-reminders
+CRON_SECRET=

--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ pnpm dev
 
 You should now be able to access the application at http://localhost:3000.
 
+## Email Reminders
+
+This project can send reminder emails using Nodemailer. Configure the SMTP
+credentials and cron secret in your `.env` file:
+
+```bash
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM="Days Since <reminders@dayssince.app>"
+CRON_SECRET=
+```
+
+Vercel triggers `/api/cron/check-reminders` daily via the schedule in
+`vercel.json`. The request must include an `Authorization` header of
+`Bearer $CRON_SECRET`.
+
 ## Running GitHub Actions Locally
 
 This project uses [act](https://github.com/nektos/act) to run GitHub Actions locally in Docker containers, providing an identical environment to GitHub's runners.


### PR DESCRIPTION
## Summary
- document reminder email configuration
- provide SMTP and CRON env vars in sample

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test && pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685ec952e0e483239021466578f09cf3