### PR TITLE
Improve mobile search UX

### DIFF
--- a/app/(dashboard)/__tests__/events-table.test.tsx
+++ b/app/(dashboard)/__tests__/events-table.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EventsTable } from '../events-table';
+import { Event } from '@/lib/db';
+
+// Mock EventItem to avoid importing server actions
+jest.mock('../event', () => ({
+  EventItem: () => <tr data-testid="event-item" />
+}));
+
+const mockEvent: Event = {
+  id: 1,
+  userId: 'user1',
+  name: 'Test Event',
+  date: '2024-01-01T00:00:00.000Z',
+  resetCount: 0,
+  createdAt: new Date('2024-01-01'),
+  reminderDays: null,
+  reminderSent: false
+};
+
+describe('EventsTable search behavior', () => {
+  it('scrolls search into view on focus', () => {
+    render(<EventsTable events={[mockEvent]} />);
+
+    const input = screen.getByPlaceholderText('Search events...');
+    const spy = jest.fn();
+    // jsdom doesn't implement scrollIntoView
+    Object.defineProperty(input, 'scrollIntoView', { value: spy, writable: true });
+
+    fireEvent.focus(input);
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/app/(dashboard)/events-table.tsx
+++ b/app/(dashboard)/events-table.tsx
@@ -15,13 +15,14 @@ import {
   CardDescription
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import Fuse from 'fuse.js';
 import { EventItem } from './event';
 import { Event } from '@/lib/db';
 
 export function EventsTable({ events }: { events: Event[] }) {
   const [query, setQuery] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
 
   const fuse = useMemo(() => {
     return new Fuse(events, {
@@ -45,9 +46,13 @@ export function EventsTable({ events }: { events: Event[] }) {
         </CardDescription>
         {events.length > 0 && (
           <Input
+            ref={searchRef}
             placeholder="Search events..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            onFocus={() =>
+              searchRef.current?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+            }
             type="search"
             className="mt-4 w-full sm:max-w-xs"
           />

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,10 @@
 import '@testing-library/jest-dom';
 
+// Polyfill TextEncoder/Decoder for Next.js
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
 // Mock Next.js router
 jest.mock('next/navigation', () => ({
   useRouter() {


### PR DESCRIPTION
## Summary
- keep search input visible when focusing on mobile
- polyfill TextEncoder/TextDecoder for tests
- add regression test for mobile search focus

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6865f50233488323af3ac52accc6ee68