### PR TITLE
Add sortable columns to events table

### DIFF
--- a/app/(dashboard)/events-table.tsx
+++ b/app/(dashboard)/events-table.tsx
@@ -19,9 +19,12 @@ import { useState, useMemo } from 'react';
 import Fuse from 'fuse.js';
 import { EventItem } from './event';
 import { Event } from '@/lib/db';
+import { ArrowUpDown } from 'lucide-react';
 
 export function EventsTable({ events }: { events: Event[] }) {
   const [query, setQuery] = useState('');
+  const [sortColumn, setSortColumn] = useState<'name' | 'date' | 'daysSince'>('date');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
 
   const fuse = useMemo(() => {
     return new Fuse(events, {
@@ -34,6 +37,37 @@ export function EventsTable({ events }: { events: Event[] }) {
     query.trim() === ''
       ? events
       : fuse.search(query).map((result) => result.item);
+
+  function handleSort(column: 'name' | 'date' | 'daysSince') {
+    if (column === sortColumn) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortColumn(column);
+      setSortDirection('asc');
+    }
+  }
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      const direction = sortDirection === 'asc' ? 1 : -1;
+      if (sortColumn === 'name') {
+        return a.name.localeCompare(b.name) * direction;
+      }
+      if (sortColumn === 'date') {
+        return (
+          (new Date(a.date).getTime() - new Date(b.date).getTime()) * direction
+        );
+      }
+      // daysSince
+      const daysA = Math.floor(
+        (Date.now() - new Date(a.date).getTime()) / (1000 * 3600 * 24)
+      );
+      const daysB = Math.floor(
+        (Date.now() - new Date(b.date).getTime()) / (1000 * 3600 * 24)
+      );
+      return (daysA - daysB) * direction;
+    });
+  }, [filtered, sortColumn, sortDirection]);
 
   return (
     <Card>
@@ -66,15 +100,33 @@ export function EventsTable({ events }: { events: Event[] }) {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Event</TableHead>
-                <TableHead>Date</TableHead>
-                <TableHead className="text-center">Days Since</TableHead>
+                <TableHead
+                  onClick={() => handleSort('name')}
+                  className="cursor-pointer select-none"
+                >
+                  Event
+                  <ArrowUpDown className="ml-1 inline h-3 w-3" />
+                </TableHead>
+                <TableHead
+                  onClick={() => handleSort('date')}
+                  className="cursor-pointer select-none"
+                >
+                  Date
+                  <ArrowUpDown className="ml-1 inline h-3 w-3" />
+                </TableHead>
+                <TableHead
+                  onClick={() => handleSort('daysSince')}
+                  className="text-center cursor-pointer select-none"
+                >
+                  Days Since
+                  <ArrowUpDown className="ml-1 inline h-3 w-3" />
+                </TableHead>
                 <TableHead className="hidden md:table-cell">Relative</TableHead>
                 <TableHead className="w-[70px]"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filtered.map((event) => (
+              {sorted.map((event) => (
                 <EventItem key={event.id} event={event} />
               ))}
             </TableBody>


### PR DESCRIPTION
## Summary
- allow sorting by event name, date, and days since
- add ArrowUpDown icons for interactive headers

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688a6d0b544c832391e536fdb360f366