### PR TITLE
feat: add natural language event creation

### DIFF
--- a/app/(dashboard)/__tests__/add-event-page.test.tsx
+++ b/app/(dashboard)/__tests__/add-event-page.test.tsx
@@ -124,6 +124,25 @@ describe('Add Event Page', () => {
     });
   });
 
+  describe('Quick Add', () => {
+    it('creates event from natural language input', async () => {
+      const user = userEvent.setup();
+      const { addEvent } = require('../actions');
+      render(<AddEventPage />);
+
+      const quickInput = screen.getByLabelText('Quick Add');
+      await user.type(quickInput, 'purchased macbook on Dec 3rd 2024');
+      await user.click(screen.getByRole('button', { name: 'Create' }));
+
+      await waitFor(() => {
+        expect(addEvent).toHaveBeenCalled();
+      });
+      const formData = (addEvent as jest.Mock).mock.calls[0][0] as FormData;
+      expect(formData.get('name')).toBe('purchased macbook');
+      expect(formData.get('date')).toBe('2024-12-03');
+    });
+  });
+
   describe('User Interactions', () => {
     it('allows user to input event name', async () => {
       const user = userEvent.setup();

--- a/app/(dashboard)/add/add-event-form.tsx
+++ b/app/(dashboard)/add/add-event-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useOptimistic, useTransition, useEffect } from 'react';
+import { useOptimistic, useTransition, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { addEvent } from '../actions';
 import { Button } from '@/components/ui/button';
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { CardContent, CardFooter } from '@/components/ui/card';
 import Link from 'next/link';
+import * as chrono from 'chrono-node';
 
 interface AddEventFormProps {
   defaultDate: string;
@@ -17,12 +18,62 @@ export function AddEventForm({ defaultDate }: AddEventFormProps) {
   const router = useRouter();
   const [message, setMessage] = useOptimistic('');
   const [isPending, startTransition] = useTransition();
+  const [quickInput, setQuickInput] = useState('');
 
   useEffect(() => {
     if (message === 'Event added!') {
       router.push('/');
     }
   }, [message, router]);
+
+  function parseNaturalInput(input: string) {
+    const results = chrono.parse(input);
+    if (results.length === 0) {
+      return null;
+    }
+    const result = results[0];
+    let name = (
+      input.slice(0, result.index) +
+      input.slice(result.index + result.text.length)
+    ).trim();
+    name = name.replace(/\b(on|in|at|by|for|after|before)\s*$/i, '').trim();
+    if (!name) {
+      name = input;
+    }
+    const date = result.date();
+    return { name, date: date.toISOString().split('T')[0] };
+  }
+
+  async function handleQuickAdd() {
+    const parsed = parseNaturalInput(quickInput);
+    if (!parsed) {
+      setMessage('Could not understand input');
+      return;
+    }
+    const formData = new FormData();
+    formData.append('name', parsed.name);
+    formData.append('date', parsed.date);
+    setMessage('Event added!');
+    startTransition(async () => {
+      await addEvent(formData);
+    });
+  }
+
+  function handleVoiceInput() {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition ||
+      (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      setMessage('Voice input not supported');
+      return;
+    }
+    const recognition = new SpeechRecognition();
+    recognition.onresult = (event: any) => {
+      const transcript = event.results[0][0].transcript;
+      setQuickInput(transcript);
+    };
+    recognition.start();
+  }
 
   async function handleSubmit(formData: FormData) {
     setMessage('Event added!');
@@ -34,6 +85,27 @@ export function AddEventForm({ defaultDate }: AddEventFormProps) {
   return (
     <form action={handleSubmit} className="contents">
       <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="quickAdd">Quick Add</Label>
+          <div className="flex gap-2">
+            <Input
+              id="quickAdd"
+              placeholder="Purchased macbook on Dec 3rd 2024"
+              value={quickInput}
+              onChange={(e) => setQuickInput(e.target.value)}
+            />
+            <Button
+              type="button"
+              onClick={handleVoiceInput}
+              aria-label="Start voice input"
+            >
+              🎤
+            </Button>
+            <Button type="button" onClick={handleQuickAdd} disabled={isPending}>
+              Create
+            </Button>
+          </div>
+        </div>
         <div className="space-y-2">
           <Label htmlFor="name">Event Name</Label>
           <Input id="name" name="name" placeholder="What happened?" required />

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@vercel/analytics": "^1.4.1",
     "autoprefixer": "^10.4.20",
     "bcryptjs": "^3.0.2",
+    "chrono-node": "^2.8.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.2
+      chrono-node:
+        specifier: ^2.8.4
+        version: 2.8.4
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2650,6 +2653,10 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
+  chrono-node@2.8.4:
+    resolution: {integrity: sha512-F+Rq88qF3H2dwjnFrl3TZrn5v4ZO57XxeQ+AhuL1C685So1hdUV/hT/q8Ja5UbmPYEZfx8VrxFDa72Dgldcxpg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -2822,6 +2829,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.13:
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -7952,6 +7962,10 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
+  chrono-node@2.8.4:
+    dependencies:
+      dayjs: 1.11.13
+
   ci-info@3.9.0: {}
 
   ci-info@4.2.0: {}
@@ -8115,6 +8129,8 @@ snapshots:
       is-data-view: 1.0.2
 
   date-fns@4.1.0: {}
+
+  dayjs@1.11.13: {}
 
   debug@3.2.7:
     dependencies:


### PR DESCRIPTION
## Summary
- add chrono-node dependency
- support quick-add natural language events with optional voice input
- test quick-add parsing

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6893d00cff3483238f04a18d033e7c2e