### PR TITLE
Send aggregated daily reminder emails

### DIFF
--- a/app/(dashboard)/__tests__/actions.test.ts
+++ b/app/(dashboard)/__tests__/actions.test.ts
@@ -3,6 +3,9 @@ import { auth } from '@/lib/auth';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
+process.env.POSTGRES_URL =
+  process.env.POSTGRES_URL || 'postgres://user:pass@localhost:5432/dummy';
+
 // Expose mocks via global to avoid hoisting issues
 
 jest.mock('@/lib/auth', () => ({
@@ -12,6 +15,8 @@ jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
 jest.mock('next/navigation', () => ({ redirect: jest.fn() }));
 
 jest.mock('@/lib/db', () => {
+  process.env.POSTGRES_URL =
+    process.env.POSTGRES_URL || 'postgres://user:pass@localhost:5432/dummy';
   const actual = jest.requireActual('@/lib/db');
   const mockReturning = jest.fn().mockResolvedValue([{ id: 1 }]);
   const mockValues = jest.fn(() => ({ returning: mockReturning }));

--- a/app/(dashboard)/__tests__/dashboard-page-private-tab.test.tsx
+++ b/app/(dashboard)/__tests__/dashboard-page-private-tab.test.tsx
@@ -17,6 +17,7 @@ jest.mock('@/lib/db', () => ({
       createdAt: new Date('2025-01-01T00:00:00.000Z'),
       reminderDays: null,
       reminderSent: false,
+      lastReminderSentAt: null,
       isPrivate: false
     },
     {
@@ -28,6 +29,7 @@ jest.mock('@/lib/db', () => ({
       createdAt: new Date('2025-01-02T00:00:00.000Z'),
       reminderDays: null,
       reminderSent: false,
+      lastReminderSentAt: null,
       isPrivate: true
     },
     {
@@ -39,6 +41,7 @@ jest.mock('@/lib/db', () => ({
       createdAt: new Date('2025-01-03T00:00:00.000Z'),
       reminderDays: 5,
       reminderSent: false,
+      lastReminderSentAt: null,
       isPrivate: false
     }
   ])

--- a/app/(dashboard)/__tests__/event-navigation.test.tsx
+++ b/app/(dashboard)/__tests__/event-navigation.test.tsx
@@ -42,6 +42,7 @@ describe('Event Navigation', () => {
     createdAt: new Date('2024-01-01'),
     reminderDays: null,
     reminderSent: false,
+    lastReminderSentAt: null,
     isPrivate: false
   };
 
@@ -170,6 +171,7 @@ describe('Event Navigation', () => {
       ...mockEvent,
       reminderDays: 5,
       reminderSent: false,
+      lastReminderSentAt: null,
       isPrivate: false
     };
 
@@ -195,6 +197,7 @@ describe('Event Navigation', () => {
       ...mockEvent,
       reminderDays: 10,
       reminderSent: false,
+      lastReminderSentAt: null,
       isPrivate: false
     };
 
@@ -262,6 +265,7 @@ describe('Event Navigation Integration', () => {
       createdAt: new Date('2024-01-01'),
       reminderDays: null,
       reminderSent: false,
+      lastReminderSentAt: null,
       isPrivate: false
     };
 

--- a/app/(dashboard)/actions.ts
+++ b/app/(dashboard)/actions.ts
@@ -63,6 +63,7 @@ export async function addEvent(formData: FormData) {
       date: date.toISOString(),
       reminderDays,
       reminderSent: false,
+      lastReminderSentAt: null,
       isPrivate,
       resettable
     })
@@ -136,6 +137,7 @@ export async function editEvent(formData: FormData) {
       date: date.toISOString(),
       reminderDays,
       reminderSent: false, // Reset reminder status when updating reminder settings
+      lastReminderSentAt: null,
       isPrivate,
       resettable
     })

--- a/app/(dashboard)/event.tsx
+++ b/app/(dashboard)/event.tsx
@@ -22,13 +22,23 @@ export function EventItem({ event }: { event: Event }) {
   const router = useRouter();
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
 
+  const now = new Date();
+  const eventDate = new Date(event.date);
+
   // Calculate days since
   const daysSince = Math.floor(
-    (new Date().getTime() - new Date(event.date).getTime()) / (1000 * 3600 * 24)
+    (now.getTime() - eventDate.getTime()) / (1000 * 3600 * 24)
   );
 
+  const lastReminderSentAt = event.lastReminderSentAt
+    ? new Date(event.lastReminderSentAt)
+    : null;
+  const reminderSentToday =
+    lastReminderSentAt !== null &&
+    lastReminderSentAt.toDateString() === now.toDateString();
+
   // Format the date
-  const formattedDate = new Date(event.date).toLocaleDateString('en-US', {
+  const formattedDate = eventDate.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -36,15 +46,28 @@ export function EventItem({ event }: { event: Event }) {
   });
 
   // Get relative time (e.g., "2 months ago")
-  const relativeTime = formatDistanceToNow(new Date(event.date), {
+  const relativeTime = formatDistanceToNow(eventDate, {
     addSuffix: true
   });
 
   // Check if reminder is due
+  const hasReminder = typeof event.reminderDays === 'number';
   const isReminderDue =
-    event.reminderDays &&
-    daysSince >= event.reminderDays &&
-    !event.reminderSent;
+    hasReminder &&
+    daysSince >= (event.reminderDays ?? 0) &&
+    !reminderSentToday;
+
+  let reminderBadgeText: string | null = null;
+  if (hasReminder) {
+    if (isReminderDue) {
+      reminderBadgeText = 'Reminder due!';
+    } else if (reminderSentToday) {
+      reminderBadgeText = 'Reminder sent today';
+    } else {
+      const remaining = (event.reminderDays ?? 0) - daysSince;
+      reminderBadgeText = `Remind in ${Math.max(remaining, 0)} days`;
+    }
+  }
 
   const handleRowClick = (e: React.MouseEvent) => {
     // Don't navigate if clicking on buttons or dropdown
@@ -68,12 +91,10 @@ export function EventItem({ event }: { event: Event }) {
       <TableCell className="font-medium">
         <div className="flex items-center gap-2">
           {event.name}
-          {event.reminderDays && (
+          {hasReminder && reminderBadgeText && (
             <Badge variant={isReminderDue ? 'destructive' : 'secondary'}>
               <Bell className="h-3 w-3 mr-1" />
-              {isReminderDue
-                ? 'Reminder due!'
-                : `Remind in ${event.reminderDays - daysSince} days`}
+              {reminderBadgeText}
             </Badge>
           )}
         </div>

--- a/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
+++ b/app/(dashboard)/events/[id]/__tests__/analytics-page.test.tsx
@@ -47,7 +47,8 @@ describe('EventAnalyticsPage', () => {
       resetCount: 3,
       createdAt: new Date('2024-01-01'),
       reminderDays: 14,
-      reminderSent: false
+      reminderSent: false,
+      lastReminderSentAt: null
     },
     totalResets: 3,
     currentStreak: 10,

--- a/app/api/cron/check-reminders/__tests__/route.integration.test.ts
+++ b/app/api/cron/check-reminders/__tests__/route.integration.test.ts
@@ -20,9 +20,19 @@ jest.mock('@/lib/db', () => {
     {
       id: 1,
       name: 'Test Event',
-      date: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000), // 8 days ago
+      date: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(), // 8 days ago
       reminderDays: 7,
       reminderSent: false,
+      lastReminderSentAt: null,
+      userId: 'test@example.com'
+    },
+    {
+      id: 2,
+      name: 'Another Event',
+      date: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
+      reminderDays: 3,
+      reminderSent: false,
+      lastReminderSentAt: null,
       userId: 'test@example.com'
     }
   ];
@@ -46,8 +56,6 @@ jest.mock('@/lib/db', () => {
 
 // Import after mocks
 import { GET } from '../route';
-import { db, events } from '@/lib/db';
-import { eq } from 'drizzle-orm';
 import nodemailer from 'nodemailer';
 
 describe('Email Reminder Integration Test', () => {
@@ -98,22 +106,26 @@ describe('Email Reminder Integration Test', () => {
     // Verify successful response
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
-    expect(data.message).toBe('Sent 1 reminders');
+    expect(data.message).toBe('Sent 1 reminder emails');
+    expect(data.checkedEvents).toBe(2);
+    expect(data.notifiedUsers).toBe(1);
 
     // Verify email was sent with correct content
     expect(mockSendMail).toHaveBeenCalledTimes(1);
-    expect(mockSendMail).toHaveBeenCalledWith({
-      from: 'test@example.com',
-      to: 'test@example.com',
-      subject: 'Reminder: Test Event - 8 days since',
-      html: expect.stringContaining('<h2>Days Since Reminder</h2>')
-    });
+    expect(mockSendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'test@example.com',
+        to: 'test@example.com',
+        subject: 'Days Since reminders: 2 events due'
+      })
+    );
 
     // Verify HTML content contains expected elements
     const emailCall = mockSendMail.mock.calls[0][0];
     expect(emailCall.html).toContain('<strong>Test Event</strong>');
-    expect(emailCall.html).toContain('<strong>8 days</strong>');
-    expect(emailCall.html).toContain('You requested to be reminded after 7 days.');
+    expect(emailCall.html).toContain('<strong>Another Event</strong>');
+    expect(emailCall.html).toContain('Reminder requested after 7 days');
+    expect(emailCall.html).toContain('Reminder requested after 3 days');
   });
 
   it('should handle SMTP errors gracefully', async () => {
@@ -133,8 +145,8 @@ describe('Email Reminder Integration Test', () => {
     // Should still return success but with 0 sent reminders
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
-    expect(data.message).toBe('Sent 0 reminders');
-    expect(data.checkedEvents).toBe(1);
+    expect(data.message).toBe('Sent 0 reminder emails');
+    expect(data.checkedEvents).toBe(2);
   });
 
   it('should reject unauthorized requests', async () => {
@@ -168,13 +180,29 @@ describe('Email Reminder Integration Test', () => {
     // Validate email structure
     expect(emailCall.from).toBe('test@example.com');
     expect(emailCall.to).toBe('test@example.com');
-    expect(emailCall.subject).toMatch(/^Reminder: .+ - \d+ days since$/);
-    
+    expect(emailCall.subject).toBe('Days Since reminders: 2 events due');
+
     // Validate HTML structure
     expect(emailCall.html).toContain('<h2>Days Since Reminder</h2>');
-    expect(emailCall.html).toContain('<p>This is a reminder about your event:');
-    expect(emailCall.html).toContain('<p>It has been');
-    expect(emailCall.html).toContain('<p>You requested to be reminded after');
-    expect(emailCall.html).toContain('<p>Visit your dashboard to update');
+    expect(emailCall.html).toContain('<ul>');
+    expect(emailCall.html).toContain('<strong>Test Event</strong>');
+    expect(emailCall.html).toContain('<strong>Another Event</strong>');
+    expect(emailCall.html).toContain('Visit your dashboard to update');
+  });
+
+  it('groups reminders by user and only sends one email per user', async () => {
+    const { req } = createMocks({
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer test-secret'
+      }
+    });
+
+    await GET(req);
+
+    expect(mockSendMail).toHaveBeenCalledTimes(1);
+    const emailCall = mockSendMail.mock.calls[0][0];
+    expect(emailCall.to).toBe('test@example.com');
+    expect(emailCall.subject).toBe('Days Since reminders: 2 events due');
   });
 });

--- a/app/api/cron/check-reminders/route.ts
+++ b/app/api/cron/check-reminders/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, events } from '@/lib/db';
-import { sql, eq, and, lt } from 'drizzle-orm';
+import { sql, and, or, inArray } from 'drizzle-orm';
 import nodemailer from 'nodemailer';
 
 // Create transporter for sending emails
@@ -48,9 +48,12 @@ export async function GET(request: NextRequest) {
       .from(events)
       .where(
         and(
-          eq(events.reminderSent, false),
           sql`${events.reminderDays} IS NOT NULL`,
-          sql`EXTRACT(DAY FROM (NOW() - ${events.date}::timestamp)) >= ${events.reminderDays}`
+          sql`EXTRACT(DAY FROM (NOW() - ${events.date}::timestamp)) >= ${events.reminderDays}`,
+          or(
+            sql`${events.lastReminderSentAt} IS NULL`,
+            sql`${events.lastReminderSentAt}::date < CURRENT_DATE`
+          )
         )
       );
 
@@ -58,61 +61,101 @@ export async function GET(request: NextRequest) {
       `Found ${eventsNeedingReminders.length} events needing reminders`
     );
 
-    let sentCount = 0;
+    const eventsByUser = new Map<
+      string,
+      (typeof eventsNeedingReminders)[number][]
+    >();
 
     for (const event of eventsNeedingReminders) {
-      try {
-        // Calculate days since
-        const eventDate = new Date(event.date);
-        const now = new Date();
-        const daysSince = Math.floor(
-          (now.getTime() - eventDate.getTime()) / (1000 * 60 * 60 * 24)
-        );
+      const userEvents = eventsByUser.get(event.userId) ?? [];
+      userEvents.push(event);
+      eventsByUser.set(event.userId, userEvents);
+    }
 
-        // Send reminder email
+    let sentCount = 0;
+
+    for (const [userEmail, userEvents] of eventsByUser) {
+      try {
+        const now = new Date();
+        const eventSummaries = userEvents.map((event) => {
+          const eventDate = new Date(event.date);
+          const daysSince = Math.floor(
+            (now.getTime() - eventDate.getTime()) / (1000 * 60 * 60 * 24)
+          );
+
+          return {
+            id: event.id,
+            name: event.name,
+            reminderDays: event.reminderDays,
+            daysSince,
+            date: eventDate
+          };
+        });
+
+        const listItemsHtml = eventSummaries
+          .map(
+            (summary) => `
+              <li>
+                <strong>${summary.name}</strong><br />
+                ${summary.daysSince} days since (${summary.date.toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                  timeZone: 'UTC'
+                })})<br />
+                Reminder requested after ${summary.reminderDays} days
+              </li>
+            `
+          )
+          .join('');
+
         const mailOptions = {
           from: process.env.SMTP_FROM || process.env.SMTP_USER,
-          to: event.userId, // Assuming userId is the email
-          subject: `Reminder: ${event.name} - ${daysSince} days since`,
+          to: userEmail,
+          subject: `Days Since reminders: ${eventSummaries.length} event${
+            eventSummaries.length === 1 ? '' : 's'
+          } due`,
           html: `
             <h2>Days Since Reminder</h2>
-            <p>This is a reminder about your event: <strong>${event.name}</strong></p>
-            <p>It has been <strong>${daysSince} days</strong> since this event occurred.</p>
-            <p>You requested to be reminded after ${event.reminderDays} days.</p>
-            <br>
+            <p>You have the following event${eventSummaries.length === 1 ? '' : 's'} with reminders due today:</p>
+            <ul>
+              ${listItemsHtml}
+            </ul>
             <p>Visit your dashboard to update or manage your events.</p>
           `
         };
 
         const emailResult = await transporter.sendMail(mailOptions);
-        console.log(`Email sent successfully for event ${event.id}:`, {
+        console.log(`Email sent successfully for user ${userEmail}:`, {
           messageId: emailResult.messageId,
-          to: event.userId,
-          daysSince
+          to: userEmail,
+          events: eventSummaries.map((summary) => summary.id)
         });
 
-        // Mark reminder as sent
+        const nowIso = now.toISOString();
+
         await db
           .update(events)
-          .set({ reminderSent: true })
-          .where(eq(events.id, event.id));
+          .set({ reminderSent: true, lastReminderSentAt: nowIso })
+          .where(inArray(events.id, eventSummaries.map((summary) => summary.id)));
 
         sentCount++;
-        console.log(`Sent reminder for event: ${event.name}`);
+        console.log(`Sent reminder email to ${userEmail}`);
       } catch (error) {
-        console.error(`Failed to send reminder for event ${event.id}:`, {
+        console.error(`Failed to send reminder email to ${userEmail}:`, {
           error: error instanceof Error ? error.message : String(error),
           stack: error instanceof Error ? error.stack : undefined,
-          eventName: event.name,
-          userId: event.userId
+          eventIds: userEvents.map((event) => event.id),
+          userId: userEmail
         });
       }
     }
 
     return NextResponse.json({
       success: true,
-      message: `Sent ${sentCount} reminders`,
-      checkedEvents: eventsNeedingReminders.length
+      message: `Sent ${sentCount} reminder emails`,
+      checkedEvents: eventsNeedingReminders.length,
+      notifiedUsers: sentCount
     });
   } catch (error) {
     console.error('Cron job error:', error);

--- a/app/api/reminders/route.ts
+++ b/app/api/reminders/route.ts
@@ -1,6 +1,6 @@
 import nodemailer from 'nodemailer';
 import { db, events } from '@/lib/db';
-import { eq, and, lt, sql } from 'drizzle-orm';
+import { and, or, sql, inArray } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 // Initialize Nodemailer transporter
@@ -47,9 +47,12 @@ export async function POST() {
       .from(events)
       .where(
         and(
-          eq(events.reminderSent, false),
           sql`${events.reminderDays} IS NOT NULL`,
-          sql`EXTRACT(DAY FROM (NOW() - ${events.date}::timestamp)) >= ${events.reminderDays}`
+          sql`EXTRACT(DAY FROM (NOW() - ${events.date}::timestamp)) >= ${events.reminderDays}`,
+          or(
+            sql`${events.lastReminderSentAt} IS NULL`,
+            sql`${events.lastReminderSentAt}::date < CURRENT_DATE`
+          )
         )
       );
 
@@ -58,64 +61,96 @@ export async function POST() {
       eventIds: eventsNeedingReminders.map((e) => e.id)
     });
 
+    const eventsByUser = new Map<
+      string,
+      (typeof eventsNeedingReminders)[number][]
+    >();
+
     for (const event of eventsNeedingReminders) {
-      console.log('📧 Reminders API: Processing event', {
-        eventId: event.id,
-        eventName: event.name,
-        userId: event.userId
+      const userEvents = eventsByUser.get(event.userId) ?? [];
+      userEvents.push(event);
+      eventsByUser.set(event.userId, userEvents);
+    }
+
+    for (const [userEmail, userEvents] of eventsByUser) {
+      console.log('📧 Reminders API: Processing reminders for user', {
+        userId: userEmail,
+        eventIds: userEvents.map((event) => event.id)
       });
 
       try {
-        // Send reminder email
-        console.log('📧 Reminders API: Sending reminder email', {
-          to: event.userId
+        const now = new Date();
+        const eventSummaries = userEvents.map((event) => {
+          const eventDate = new Date(event.date);
+          const daysSince = Math.floor(
+            (now.getTime() - eventDate.getTime()) / (1000 * 60 * 60 * 24)
+          );
+
+          return {
+            id: event.id,
+            name: event.name,
+            reminderDays: event.reminderDays,
+            daysSince,
+            date: eventDate
+          };
         });
 
-        // Calculate actual days since
-        const eventDate = new Date(event.date);
-        const now = new Date();
-        const daysSince = Math.floor(
-          (now.getTime() - eventDate.getTime()) / (1000 * 60 * 60 * 24)
-        );
+        const listItemsHtml = eventSummaries
+          .map(
+            (summary) => `
+              <li>
+                <strong>${summary.name}</strong><br />
+                ${summary.daysSince} days since (${summary.date.toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                  timeZone: 'UTC'
+                })})<br />
+                Reminder requested after ${summary.reminderDays} days
+              </li>
+            `
+          )
+          .join('');
 
         const info = await transporter.sendMail({
           from: process.env.SMTP_FROM || process.env.SMTP_USER,
-          to: event.userId,
-          subject: `Reminder: ${event.name} - ${daysSince} days since`,
+          to: userEmail,
+          subject: `Days Since reminders: ${eventSummaries.length} event${
+            eventSummaries.length === 1 ? '' : 's'
+          } due`,
           html: `
             <h2>Days Since Reminder</h2>
-            <p>This is a reminder about your event: <strong>${event.name}</strong></p>
-            <p>It has been <strong>${daysSince} days</strong> since this event occurred.</p>
-            <p>You requested to be reminded after ${event.reminderDays} days.</p>
-            <br>
+            <p>You have the following event${eventSummaries.length === 1 ? '' : 's'} with reminders due today:</p>
+            <ul>
+              ${listItemsHtml}
+            </ul>
             <p>Visit your dashboard to update or manage your events.</p>
           `
         });
 
         console.log('📧 Reminders API: Email sent successfully', {
           info,
-          eventId: event.id
+          userId: userEmail
         });
 
-        // Mark reminder as sent
-        console.log('📧 Reminders API: Marking reminder as sent', {
-          eventId: event.id
-        });
+        const nowIso = now.toISOString();
 
         await db
           .update(events)
-          .set({ reminderSent: true })
-          .where(eq(events.id, event.id));
+          .set({ reminderSent: true, lastReminderSentAt: nowIso })
+          .where(inArray(events.id, eventSummaries.map((summary) => summary.id)));
 
         console.log('📧 Reminders API: Reminder marked as sent', {
-          eventId: event.id
+          userId: userEmail,
+          eventIds: eventSummaries.map((summary) => summary.id)
         });
       } catch (error) {
-        console.error('📧 Reminders API: Error processing event', {
-          eventId: event.id,
+        console.error('📧 Reminders API: Error processing reminders for user', {
+          userId: userEmail,
+          eventIds: userEvents.map((event) => event.id),
           error: error instanceof Error ? error.message : String(error)
         });
-        // Continue with other events even if one fails
+        // Continue with other users even if one fails
       }
     }
 

--- a/drizzle/migrations/0006_add_last_reminder_sent_at.sql
+++ b/drizzle/migrations/0006_add_last_reminder_sent_at.sql
@@ -1,0 +1,9 @@
+-- Track when reminders were last delivered so they can be sent daily
+ALTER TABLE IF EXISTS "events"
+  ADD COLUMN IF NOT EXISTS "last_reminder_sent_at" TIMESTAMPTZ;
+
+-- Backfill existing data: any event previously marked as reminded should
+-- get a timestamp so we don't resend immediately after deploying.
+UPDATE "events"
+SET "last_reminder_sent_at" = COALESCE("last_reminder_sent_at", NOW())
+WHERE "reminder_sent" = TRUE;

--- a/lib/__tests__/db-analytics.test.ts
+++ b/lib/__tests__/db-analytics.test.ts
@@ -131,7 +131,8 @@ describe('Event Analytics', () => {
     resetCount: 3,
     createdAt: new Date('2024-01-01'),
     reminderDays: null,
-    reminderSent: false
+    reminderSent: false,
+    lastReminderSentAt: null
   };
 
   const mockResets: EventReset[] = [

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -57,6 +57,7 @@ export const events = pgTable('events', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
   reminderDays: integer('reminder_days'),
   reminderSent: boolean('reminder_sent').notNull().default(false),
+  lastReminderSentAt: timestamp('last_reminder_sent_at'),
   // Whether the event is private to the user and hidden from public views
   isPrivate: boolean('is_private').notNull().default(false),
   // Whether the event can be reset by the user (true by default)


### PR DESCRIPTION
## Summary
- add `lastReminderSentAt` tracking to events with a migration so reminders can be limited to once per day
- update cron and reminder endpoints to group due events per user and send a single Mailtrap email listing each reminder
- refresh dashboard reminder badges and supporting tests/mocks for the new reminder timing behaviour

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68c9812f378c8320a16833c5d590ff71