### PR TITLE
Add ability to duplicate events

### DIFF
--- a/app/(dashboard)/__tests__/actions.test.ts
+++ b/app/(dashboard)/__tests__/actions.test.ts
@@ -24,6 +24,11 @@ jest.mock('@/lib/db', () => {
   const mockWhere = jest.fn(() => ({ returning: mockReturning }));
   const mockSet = jest.fn(() => ({ where: mockWhere }));
   const mockUpdate = jest.fn(() => ({ set: mockSet }));
+  let mockSelectResult: any[] = [];
+  const mockLimit = jest.fn(() => Promise.resolve(mockSelectResult));
+  const mockWhereSelect = jest.fn(() => ({ limit: mockLimit }));
+  const mockFrom = jest.fn(() => ({ where: mockWhereSelect, limit: mockLimit }));
+  const mockSelect = jest.fn(() => ({ from: mockFrom }));
 
   (global as any).dbTestMocks = {
     mockInsert,
@@ -31,23 +36,31 @@ jest.mock('@/lib/db', () => {
     mockReturning,
     mockUpdate,
     mockSet,
-    mockWhere
+    mockWhere,
+    mockSelect,
+    mockFrom,
+    mockWhereSelect,
+    mockLimit,
+    setSelectResult: (result: any[]) => {
+      mockSelectResult = result;
+    }
   };
 
   return {
     ...actual,
-    db: { insert: mockInsert, update: mockUpdate },
+    db: { insert: mockInsert, update: mockUpdate, select: mockSelect },
     events: actual.events
   };
 });
 
-import { addEvent, editEvent } from '../actions';
+import { addEvent, editEvent, duplicateEvent } from '../actions';
 import { events } from '@/lib/db';
 const mockAuth = auth as unknown as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockAuth.mockResolvedValue({ user: { email: 'user@example.com' } });
+  (global as any).dbTestMocks.setSelectResult([]);
 });
 
 describe('addEvent', () => {
@@ -173,5 +186,79 @@ describe('editEvent', () => {
     expect((global as any).dbTestMocks.mockSet).toHaveBeenCalledWith(
       expect.objectContaining({ isPrivate: false })
     );
+  });
+});
+
+describe('duplicateEvent', () => {
+  it('duplicates event with copy suffix', async () => {
+    (global as any).dbTestMocks.setSelectResult([
+      {
+        id: 1,
+        userId: 'user@example.com',
+        name: 'Original Event',
+        date: '2025-06-01T00:00:00.000Z',
+        reminderDays: 10,
+        isPrivate: true,
+        resettable: false,
+        reminderSent: true,
+        lastReminderSentAt: new Date('2025-06-10T00:00:00.000Z')
+      }
+    ]);
+
+    const formData = new FormData();
+    formData.append('id', '1');
+
+    await duplicateEvent(formData);
+
+    expect((global as any).dbTestMocks.mockInsert).toHaveBeenCalledWith(events);
+    expect((global as any).dbTestMocks.mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user@example.com',
+        name: 'Original Event (Copy)',
+        date: '2025-06-01T00:00:00.000Z',
+        reminderDays: 10,
+        isPrivate: true,
+        resettable: false,
+        reminderSent: false,
+        lastReminderSentAt: null
+      })
+    );
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+  });
+
+  it('throws when event is not found', async () => {
+    (global as any).dbTestMocks.setSelectResult([]);
+
+    const formData = new FormData();
+    formData.append('id', '1');
+
+    await expect(duplicateEvent(formData)).rejects.toThrow(
+      'Event not found or access denied'
+    );
+    expect((global as any).dbTestMocks.mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('throws when event belongs to different user', async () => {
+    (global as any).dbTestMocks.setSelectResult([
+      {
+        id: 1,
+        userId: 'other@example.com',
+        name: 'Original Event',
+        date: '2025-06-01T00:00:00.000Z',
+        reminderDays: null,
+        isPrivate: false,
+        resettable: true,
+        reminderSent: false,
+        lastReminderSentAt: null
+      }
+    ]);
+
+    const formData = new FormData();
+    formData.append('id', '1');
+
+    await expect(duplicateEvent(formData)).rejects.toThrow(
+      'Event not found or access denied'
+    );
+    expect((global as any).dbTestMocks.mockInsert).not.toHaveBeenCalled();
   });
 });

--- a/app/(dashboard)/actions.ts
+++ b/app/(dashboard)/actions.ts
@@ -87,6 +87,45 @@ export async function deleteEvent(formData: FormData) {
   revalidatePath('/');
 }
 
+export async function duplicateEvent(formData: FormData) {
+  const session = await auth();
+  if (!session?.user?.email) {
+    throw new Error('You must be logged in to duplicate an event');
+  }
+
+  const rawId = formData.get('id');
+  const id = rawId ? Number(rawId) : NaN;
+
+  if (!Number.isInteger(id)) {
+    throw new Error('Invalid event ID');
+  }
+
+  const existingEvents = await db
+    .select()
+    .from(events)
+    .where(eq(events.id, id))
+    .limit(1);
+
+  const originalEvent = existingEvents[0];
+
+  if (!originalEvent || originalEvent.userId !== session.user.email) {
+    throw new Error('Event not found or access denied');
+  }
+
+  await db.insert(events).values({
+    userId: session.user.email,
+    name: `${originalEvent.name} (Copy)`,
+    date: originalEvent.date,
+    reminderDays: originalEvent.reminderDays,
+    reminderSent: false,
+    lastReminderSentAt: null,
+    isPrivate: originalEvent.isPrivate,
+    resettable: originalEvent.resettable
+  });
+
+  revalidatePath('/');
+}
+
 export async function deleteProduct(formData: FormData) {
   const session = await auth();
   if (!session?.user?.email) {

--- a/app/(dashboard)/event.tsx
+++ b/app/(dashboard)/event.tsx
@@ -11,7 +11,7 @@ import {
 import { MoreHorizontal, Bell } from 'lucide-react';
 import { TableCell, TableRow } from '@/components/ui/table';
 import { Event } from '@/lib/db';
-import { deleteEvent } from './actions';
+import { deleteEvent, duplicateEvent } from './actions';
 import { formatDistanceToNow } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
 import { ResetButton } from './reset-button';
@@ -125,6 +125,14 @@ export function EventItem({ event }: { event: Event }) {
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <a href={`/edit/${event.id}`}>Edit</a>
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <form action={duplicateEvent}>
+                <input type="hidden" name="id" value={event.id} />
+                <button type="submit" className="w-full text-left">
+                  Duplicate
+                </button>
+              </form>
             </DropdownMenuItem>
             <DropdownMenuItem>
               <form action={deleteEvent}>


### PR DESCRIPTION
## Summary
- add a server action to duplicate an event for the authenticated user while resetting reminder state
- expose a Duplicate option in the event row menu so users can clone existing events
- extend action tests with database select mocks and new duplicate event scenarios

## Testing
- pnpm lint
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6901136ad8e0832088f5a0567da9ce2a)