### PR TITLE
chore: allow mem0 and pnpm install tools in local settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(git -C /Users/janac/Documents/GitHub/days-since-nextjs push)",
       "Bash(pnpm jest:*)",
       "Bash(gh api:*)",
-      "mcp__plugin_mem0_mem0__search_memories"
+      "mcp__plugin_mem0_mem0__search_memories",
+      "Bash(pnpm install *)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(git -C /Users/janac/Documents/GitHub/days-since-nextjs log --oneline -3)",
       "Bash(git -C /Users/janac/Documents/GitHub/days-since-nextjs push)",
       "Bash(pnpm jest:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "mcp__plugin_mem0_mem0__search_memories"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary
- Add `mcp__plugin_mem0_mem0__search_memories` to the local Claude settings allowlist
- Add `Bash(pnpm install *)` to the local Claude settings allowlist

These are `.claude/settings.local.json` permission entries only — no application code changes.

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm lint` passes
- [ ] Note: one pre-existing, unrelated test failure exists in `lib/__tests__/migration-checker.test.ts` (not touched by this PR)