### PR TITLE
fix(test): stop automocking drizzle-orm/neon-http, document local dev setup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,9 @@
       "Bash(pnpm jest:*)",
       "Bash(gh api:*)",
       "mcp__plugin_mem0_mem0__search_memories",
-      "Bash(pnpm install *)"
+      "Bash(pnpm install *)",
+      "Bash(npx tsx *)",
+      "Bash(pnpm why *)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,9 @@
       "mcp__plugin_mem0_mem0__search_memories",
       "Bash(pnpm install *)",
       "Bash(npx tsx *)",
-      "Bash(pnpm why *)"
+      "Bash(pnpm why *)",
+      "Bash(corepack prepare *)",
+      "Bash(pnpm --version)"
     ],
     "deny": [],
     "ask": []

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,23 +2,32 @@
 
 ## Setup
 
-This repository uses **pnpm** (lockfile is committed). If `pnpm` is missing:
+This repository uses **pnpm 9**. Use that version, not whatever `corepack enable pnpm` gives you:
 
 ```bash
 corepack enable pnpm
-corepack prepare pnpm@9 --activate   # see version note below
+corepack prepare pnpm@9 --activate
 pnpm install
 ```
 
-Pin **pnpm 9**. `pnpm-lock.yaml` is `lockfileVersion: '9.0'`, and installing with pnpm 11 rewrites
-~580 lines of peer-dependency annotations (`(supports-color@8.1.1)` suffixes) with no actual version
-changes — pure diff noise. Note that `.github/workflows/pr-tests.yml` pins `version: 8` via
-`pnpm/action-setup`, which predates `lockfileVersion 9.0`; that mismatch is unresolved, so don't
-treat CI's 8 as the intended local version.
+Three reasons pnpm 9 specifically:
 
-`pnpm-workspace.yaml` declares `allowBuilds` for `esbuild` and `sharp`. pnpm blocks post-install
-build scripts by default and refuses to run *any* script while approvals are pending — without that
-file, `pnpm dev` exits 1 with `ERR_PNPM_IGNORED_BUILDS`. Don't delete it.
+- `pnpm-lock.yaml` is `lockfileVersion: '9.0'`. Installing with pnpm 11 rewrites ~580 lines of
+  peer-dependency annotations (`(supports-color@8.1.1)` suffixes) with no actual version changes —
+  pure diff noise. pnpm 9 leaves the lockfile untouched.
+- Vercel picks pnpm 9 for this project on its own (`Detected pnpm-lock.yaml 9 ... Using pnpm@9.x
+  based on project creation date`), so local pnpm 9 matches the deploy.
+- pnpm 10+ blocks post-install build scripts and then refuses to run *any* script while approvals
+  are pending, so `pnpm dev` exits 1 with `ERR_PNPM_IGNORED_BUILDS` for `esbuild` and `sharp`.
+  pnpm 9 has no such gate and just builds them.
+
+If you must use pnpm 10 or 11, run `pnpm approve-builds esbuild sharp` — but do **not** commit the
+`pnpm-workspace.yaml` it generates. That file makes pnpm 9 treat the repo as a workspace, and it then
+fails the Vercel build with `ERROR packages field missing or empty`. The `pnpm.onlyBuiltDependencies`
+field in `package.json` is not an alternative — pnpm 11 ignores it.
+
+`.github/workflows/pr-tests.yml` pins `version: 8` via `pnpm/action-setup`, which predates
+`lockfileVersion 9.0`. That mismatch is unresolved; don't treat CI's 8 as the intended local version.
 
 ## Environment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,64 @@
 # AGENTS Instructions
 
-This repository uses **pnpm** for development. Ensure dependencies are installed with `pnpm install`.
+## Setup
 
-Copy `.env.example` to `.env` and provide any required values before running scripts.
+This repository uses **pnpm** (lockfile is committed). If `pnpm` is missing:
 
-Before committing any changes, run:
+```bash
+corepack enable pnpm
+corepack prepare pnpm@9 --activate   # see version note below
+pnpm install
+```
+
+Pin **pnpm 9**. `pnpm-lock.yaml` is `lockfileVersion: '9.0'`, and installing with pnpm 11 rewrites
+~580 lines of peer-dependency annotations (`(supports-color@8.1.1)` suffixes) with no actual version
+changes — pure diff noise. Note that `.github/workflows/pr-tests.yml` pins `version: 8` via
+`pnpm/action-setup`, which predates `lockfileVersion 9.0`; that mismatch is unresolved, so don't
+treat CI's 8 as the intended local version.
+
+`pnpm-workspace.yaml` declares `allowBuilds` for `esbuild` and `sharp`. pnpm blocks post-install
+build scripts by default and refuses to run *any* script while approvals are pending — without that
+file, `pnpm dev` exits 1 with `ERR_PNPM_IGNORED_BUILDS`. Don't delete it.
+
+## Environment
+
+Do **not** hand-write `.env` from `.env.example`. The real values live in the Vercel project
+`janaclazertechnols-projects/days-since-nextjs`, where the Neon integration injects the Postgres
+vars. Pull them:
+
+```bash
+vercel link --yes
+vercel env pull .env.local --environment=development
+```
+
+Set `NEXTAUTH_URL=http://localhost:3000` locally — Vercel has no development value for it, and
+`env pull` preserves it if already present.
+
+`lib/db.ts` connects with `@neondatabase/serverless`'s `neon()` HTTP driver, so `POSTGRES_URL` must
+point at a Neon host (or the Neon local proxy). A plain local `postgres://` will not answer.
+
+Vercel's Development environment points at the **same Neon branch as production**. This is
+intentional for this project — testing against live data is accepted. Writes made while clicking
+through the dev server are real.
+
+### `.env` vs `.env.local`
+
+Next.js loads `.env.local` automatically, but bare `dotenv/config` defaults to `.env`. `lib/migrate.ts`
+handles this itself (`config({ path: '.env.local' })`); `scripts/run-migrations.ts` does not, so run it
+with an explicit env file:
+
+```bash
+npx tsx --env-file=.env.local scripts/run-migrations.ts
+```
+
+## Running
+
+```bash
+pnpm dev          # http://localhost:3000 — `/` redirects to `/login` when signed out
+pnpm db:migrate
+```
+
+## Before committing
 
 ```bash
 pnpm lint
@@ -17,4 +71,11 @@ Before pushing, verify that tests and the build succeed:
 pnpm test && pnpm build
 ```
 
-Code style is enforced with Prettier and ESLint. Running `pnpm lint` will check formatting and lint rules.
+Code style is enforced with Prettier and ESLint. Running `pnpm lint` will check formatting and lint
+rules.
+
+## Known warnings (not bugs — don't chase them)
+
+- `The "middleware" file convention is deprecated. Please use "proxy" instead.` — Next 16 renamed the
+  convention; `middleware.ts` still works.
+- `caniuse-lite is N months old` — refresh with `npx update-browserslist-db@latest` when convenient.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/lib/__tests__/migration-checker.test.ts
+++ b/lib/__tests__/migration-checker.test.ts
@@ -14,7 +14,12 @@ import {
 
 // Mock dependencies
 jest.mock('@neondatabase/serverless');
-jest.mock('drizzle-orm/neon-http');
+// Use an explicit factory rather than an automock: drizzle-orm's `drizzle`
+// export carries its own `mock` property (drizzle.mock()), and automocking
+// copies that onto the generated mock function. jest defines `.mock` with a
+// setter that writes its internal mock-state map, so the copy replaces that
+// state with a function and every later call dies in _ensureMockState.
+jest.mock('drizzle-orm/neon-http', () => ({ drizzle: jest.fn() }));
 jest.mock('fs');
 jest.mock('path');
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: true
-  sharp: true


### PR DESCRIPTION
## Why

Two problems, both found while setting this repo up from a clean clone.

**1. `main` was red, which blocked every commit.** `lib/__tests__/migration-checker.test.ts` was failing on `32ca83c0`, and the husky pre-commit hook runs `pnpm lint && pnpm test` — so nobody could commit anything without `--no-verify`.

**2. The setup instructions didn't work.** `AGENTS.md` said to copy `.env.example` to `.env`; that path doesn't produce a running app.

## The test failure was a real bug, not a stale mock

`drizzle-orm`'s `drizzle` export has an own property named **`mock`** (the `drizzle.mock()` helper):

```
Object.getOwnPropertyNames(real.drizzle)  →  ["length", "name", "prototype", "mock"]
```

`jest.mock('drizzle-orm/neon-http')` automocks the module by copying the real function's own properties onto the generated mock. But jest defines `.mock` on mock functions with a **setter that writes its internal mock-state map**. So the copy replaced that state with a function, and the next call died:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at ModuleMocker._ensureMockState (jest-mock/build/index.js:292:21)   // state.calls.length
    at mockConstructor (jest-mock/build/index.js:148:19)
    at drizzle (eval at _createMockFunction ...)
```

Net effect: `drizzle()` threw instead of returning the configured `mockDb`, so `checkMigrationStatus()` bailed before its loop — `totalMigrations: 0`, `db.execute` never called, `isUpToDate` false.

Two things obscured this:

- The `TypeError` is constructed in **jsdom's realm**, so `error instanceof Error` at `lib/migration-checker.ts:109` is `false` and the real message was discarded in favour of `"Failed to check migration status: Unknown error"`.
- `console.error` is spied on in `beforeEach`, swallowing the trace.

**Fix:** an explicit factory mock, so the real module's properties are never copied. `@neondatabase/serverless` was checked for the same collision — `neon` has no `.mock` property, so its automock is left alone.

## Docs

`AGENTS.md` now covers what actually blocked a clean setup:

- **Pin pnpm 9.** The lockfile is `lockfileVersion: '9.0'`; installing with pnpm 11 rewrites ~580 lines of peer-dependency annotations for no real change, and pnpm 10+ blocks `esbuild`/`sharp` post-install scripts then refuses to run *any* script (`ERR_PNPM_IGNORED_BUILDS`). pnpm 9 has no such gate, and Vercel independently picks pnpm 9 for this project — so one version covers local, CI, and deploy.
- **`vercel env pull`** is the env source, not `.env.example`. The Neon integration injects the Postgres vars into the Vercel project.
- **`lib/db.ts` uses the `@neondatabase/serverless` HTTP driver**, so `POSTGRES_URL` must be a Neon host — a local `postgres://` never answers. Saves the next person from standing up a local Postgres.

Also documented: the `.env` vs `.env.local` split that `scripts/run-migrations.ts` doesn't handle, and the two benign Next 16 warnings (`middleware`→`proxy`, stale `caniuse-lite`) so they aren't mistaken for regressions.

`CLAUDE.md` is a symlink to `AGENTS.md` to keep one source of truth.

### Note on the second commit

The first commit pre-approved the `esbuild`/`sharp` builds via a generated `pnpm-workspace.yaml`. That **broke the Vercel build** — its presence makes pnpm 9 treat the repo as a workspace root, which then requires a `packages:` field:

```
ERROR  packages field missing or empty
Error: Command "pnpm install" exited with 1
```

`dd4491f8` removes it and pins pnpm 9 instead, which sidesteps the approval mechanism entirely. `pnpm.onlyBuiltDependencies` in `package.json` was tried and rejected — pnpm 11 ignores it and still errors. `AGENTS.md` warns against re-committing the generated file.

## Verification

- `pnpm lint` — clean
- `pnpm test` — **15/15 suites, 148/148 tests** (was 14/15, 147/148)
- `pnpm build` — succeeds
- From-scratch install in a clean worktree on **pnpm 9.15.9**: no ignored-builds error, scripts run, lockfile untouched
- Pre-commit hook passed on its own for both commits; no `--no-verify`
- Confirmed the test failure pre-dated this branch by running the suite against a clean worktree of `32ca83c0`
- `package.json` and `pnpm-lock.yaml` are **unchanged** by this PR

## Not addressed here

- **`.github/workflows/pr-tests.yml:36` pins pnpm `version: 8`** while the lockfile is `lockfileVersion 9.0`. `build-test` currently passes, but the mismatch is worth a look; documented rather than silently changed.
- **`jest-environment-jsdom` is pinned to `30.0.0-beta.3`** while the rest of jest is `29.7.0`, pulling in a second `jest-mock` at `30.0.0-beta.3`. Aligning it to `^29.7.0` did *not* fix this test (identical crash), so it's out of scope — but it's a genuine latent smell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)